### PR TITLE
Faster psim / cleanup

### DIFF
--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/VariablePlots.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/VariablePlots.py
@@ -11,7 +11,7 @@ parser.add_argument("source", help="Name of source folder from home directory", 
 parser.add_argument("destination", help="Name of destination folder from home directory", type=str)
 parser.add_argument("numGens", help="Number of generations the code is running for", type=int)
 parser.add_argument("NPOP", help="Number of individuals in a population", type=int)
-parser.add_argument("GeoScalingFactor", help="The number by which we are scaling the antenna dimensions", type=int)
+parser.add_argument("GeoScalingFactor", help="The number by which we are scaling the antenna dimensions", type=float)
 g = parser.parse_args()
 
 # The name of the plot that will be put into the destination folder, g.destination

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/XFintoPUEO_Symmetric.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/XFintoPUEO_Symmetric.py
@@ -31,7 +31,7 @@ g = parser.parse_args()
 ## Function Definitions
 ## Function to read in files
 def read_file(indiv, freq_num, col):
-    uanname = g.working_dir / 'Run_Outputs' / g.run_name / '{g.gen}_{indiv}_{freqNum}.uan'
+    uanname = g.working_dir / 'Run_Outputs' / g.run_name / f'{g.gen}_{indiv}_{freq_num}.uan'
     data = np.genfromtxt(uanname, unpack=True, skip_header=18).tolist()
 
     return data[col]  # Return the gain for the polarization being read
@@ -43,8 +43,8 @@ def getGains(indiv):
     hpol_gains = []
 
     for freq in range(num_freq):
-        vpol_gains.append(readFile(indiv, freq+1, 2))
-        hpol_gains.append(readFile(indiv, freq+1, 3))
+        vpol_gains.append(read_file(indiv, freq+1, 2))
+        hpol_gains.append(read_file(indiv, freq+1, 3))
 
     return vpol_gains, hpol_gains
 

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/XFintoPUEO_Symmetric.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/XFintoPUEO_Symmetric.py
@@ -52,7 +52,7 @@ def getGains(indiv):
 def writeGains(data, freq_list, file_name):
     with open(file_name, "a") as f:
         for i in range(num_freq):
-            f.write('{freq_list[i]} {data[i]}\n')
+            f.write(f'{freq_list[i]} {data[i]}\n')
 
 
 ## Function calls

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/gensDataPUEO.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/gensDataPUEO.py
@@ -2,18 +2,20 @@
 # Written on: 	Dec 21, 2018
 # Reads from: 	generationDNA.csv, fitnessScores.csv
 # Writes to: 	maxFitnessScores.csv, runData.csv (formerly gensData.csv)
-# Purpose:	Take data from fitness algorithm and record relevant data: the maximum fitness score and the total information for each antenna. Dynamically adjusts for any NPOP.
+# Purpose:	Take data from fitness algorithm and record relevant data: the 
+# maximum fitness score and the total information for each antenna. Dynamically adjusts for any NPOP.
 
 import numpy as np
 import argparse
+
+from pathlib import Path
 
 #---------GLOBAL VARIABLES----------GLOBAL VARIABLES----------GLOBAL VARIABLES----------GLOBAL VARIABLES
 
 # We need to grab the generation number this code is being run on from the bash script
 parser = argparse.ArgumentParser()
-
-parser.add_argument("GenNumber", help="Generation number the code is running on (for formatting purposes)", type=int)
-parser.add_argument("location", help="Location of runData.csv and fitness.csv", type=str)
+parser.add_argument("gen_num", help="generation number", type=int)
+parser.add_argument("location", help="Location of runData.csv and fitness.csv", type=Path)
 g = parser.parse_args()
 
 #----------STARTS HERE----------STARTS HERE----------STARTS HERE----------STARTS HERE 
@@ -23,9 +25,10 @@ g = parser.parse_args()
 # Read maxFitnessScores.csv, generationDNA.csv, and fitnessScores.csv
 
 # We use loadtxt when we need to skip over the useless text
-genDNA = np.loadtxt(g.location + "/" + str(g.GenNumber) + "_generationDNA.csv", delimiter=',', skiprows=9)
-fScores = np.loadtxt(g.location + "/" + str(g.GenNumber) + "_fitnessScores.csv", delimiter=',', skiprows=0)
-
+genDNA = np.loadtxt(g.location / f'{g.gen_num}_generationDNA.csv', 
+                    delimiter=',', skiprows=9)
+fScores = np.loadtxt(g.location / f'{g.gen_num}_fitnessScores.csv', 
+                     delimiter=',', skiprows=0)
 
 # Create/Add to runData.csv
 # This file contains every antenna's DNA and fitness score for each generation. 
@@ -51,8 +54,8 @@ Generation :1
 # First, stick genDNA with fScores to have the correct matrix format described above
 genDNAfScore = np.hstack(( genDNA, fScores.reshape((fScores.shape[0], 1)) ))
 # Open the file and append the relevant information
-with open(g.location + "/runData.csv", "a+") as runData:
-	runData.write('\n'+ "Generation :"+ str(g.GenNumber)+ '\n')
+with open(g.location / 'runData.csv', 'a+') as runData:
+	runData.write(f'\nGeneration :{g.gen_num}\n')
 	np.savetxt(runData, genDNAfScore, delimiter=",", fmt='%f')
 
 
@@ -62,28 +65,29 @@ with open(g.location + "/runData.csv", "a+") as runData:
 # First, we need to find the maximum fitness score
 maxFScore = fScores.max()
 # Then, append this onto the maxFitnessScores list
-with open(g.location + "/maxFitnessScores.csv", "a+") as maxFScores:
-	maxFScores.write("Generation "+str(g.GenNumber)+"'s Max Fitness Score: "+str(maxFScore)+ '\n')
+with open(g.location / 'maxFitnessScores.csv', 'a+') as maxFScores:
+	maxFScores.write(f"Generation {g.gen_num}'s Max Fitness Score:{maxFScore} \n")
 
 # First, we need to find the minimum fitness score
 minFScore = fScores.min()
 # Then, append this onto the minFitnessScores list
-with open(g.location + "/minFitnessScores.csv", "a+") as minFScores:
-	minFScores.write("Generation "+str(g.GenNumber)+"'s Min Fitness Score: "+str(minFScore)+ '\n')
+with open(g.location / "minFitnessScores.csv", "a+") as minFScores:
+	minFScores.write(f"Generation {g.gen_num}'s Min Fitness Score: g.{minFScore}\n")
 
 # errorBars are in format Plus, Minus
 # Load in the errorBars.csv file
-errorBarsPlus, errorBarsMinus = np.loadtxt(g.location + "/" + str(g.GenNumber) + "_errorBars.csv", delimiter=',', skiprows=0, unpack=True)
+errorBarsPlus, errorBarsMinus = np.loadtxt(g.location / f"{g.gen_num}_errorBars.csv",
+                                           delimiter=',', skiprows=0, unpack=True)
 
 maxErrorBarPlus = errorBarsPlus.max()
 maxErrorBarMinus = errorBarsMinus.max()
 maxErrorBar = max(maxErrorBarPlus, maxErrorBarMinus)
 
 #then, append this onto the maxErrorBars list
-with open(g.location + "/maxErrorBars.csv", "a+") as maxErrorBars:
-	maxErrorBars.write("Generation "+str(g.GenNumber)+"'s Max Error Bar: "+str(maxErrorBar)+ '\n')
+with open(g.location / "maxErrorBars.csv", "a+") as maxErrorBars:
+	maxErrorBars.write(f"Generation {g.gen_num}'s Max Error Bar: {maxErrorBar}\n")
 
 #Now add these values to the plottingData.csv file
-with open(g.location + "/plottingData.csv", "a+") as plottingData:
-	plottingData.write(str(maxFScore)+","+str(minFScore)+","+str(maxErrorBar)+"\n")
+with open(g.location / "plottingData.csv", "a+") as plottingData:
+	plottingData.write(f"{maxFScore},{minFScore},{maxErrorBar}\n")
 	

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/gensDataPUEO.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/gensDataPUEO.py
@@ -23,8 +23,8 @@ g = parser.parse_args()
 # Read maxFitnessScores.csv, generationDNA.csv, and fitnessScores.csv
 
 # We use loadtxt when we need to skip over the useless text
-genDNA = np.loadtxt(g.location + "/" + str(g.GenNumber)+"_generationDNA.csv", delimiter=',', skiprows=8)
-fScores = np.loadtxt(g.location + "/" + str(g.GenNumber)+"_fitnessScores.csv", delimiter=',', skiprows=0)
+genDNA = np.loadtxt(g.location + "/" + str(g.GenNumber) + "_generationDNA.csv", delimiter=',', skiprows=9)
+fScores = np.loadtxt(g.location + "/" + str(g.GenNumber) + "_fitnessScores.csv", delimiter=',', skiprows=0)
 
 
 # Create/Add to runData.csv

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/image_maker.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/image_maker.sh
@@ -57,7 +57,7 @@ source $PSIMDIR/set_env.sh
 #source $PSIMDIR/set_env.sh
 
 echo "starting PORP"
-ls -alrt
+#ls -alrt
 
 echo "max index: $max_index"
 echo "exp: $exp"

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/image_maker.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/image_maker.sh
@@ -27,11 +27,12 @@ RunName=$6
 NPOP=$7
 PSIMDIR=$8
 exp=$9
+SYMMETRY=${10}
 #
-echo $fitnessSourceDir
-echo $photoSourceDir
-echo $destinationDir
-echo $RunName
+#echo $fitnessSourceDir
+#echo $photoSourceDir
+#echo $destinationDir
+#echo $RunName
 #
 cd $WorkingDir/Antenna_Performance_Metric
 ### Creates a temporary file to hold the index of the best detector
@@ -43,7 +44,7 @@ echo "touched temp files"
 ### Runs a Python script that identifies the index of the best detector
 python3 image_finder.py $fitnessSourceDir $gen
 #
-echo "past iamge finder"
+echo "found best detectors"
 ### Stores the indices of the best, middle, and worst individuals in variables
 max_index=`cat temp_best.csv`
 mid_index=`cat temp_mid.csv`
@@ -56,23 +57,23 @@ module unload python/3.7-2019.10
 source $PSIMDIR/set_env.sh
 #source $PSIMDIR/set_env.sh
 
-echo "starting PORP"
+echo "starting Physics of Results Plots"
 #ls -alrt
 
-echo "max index: $max_index"
-echo "exp: $exp"
+#echo "max index: $max_index"
+#echo "exp: $exp"
 
 python physicsOfResultsPUEO.py $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files $WorkingDir/Run_Outputs/$RunName/Generation_Data $max_index $exp
 
+echo "finished Physics of Results Plots"
+
+echo "copying best detector photos"
+
 mkdir -p ${destinationDir}/LabelledDetectorPhotos/${gen}_labelled_photos
-mv ${photoSourceDir}/${max_index}_detector.png ${destinationDir}/${gen}_detector_photos/${gen}_${max_index}_detector_max.png
-mv ${photoSourceDir}/${mid_index}_detector.png ${destinationDir}/${gen}_detector_photos/${gen}_${mid_index}_detector_mid.png
-mv ${photoSourceDir}/${min_index}_detector.png ${destinationDir}/${gen}_detector_photos/${gen}_${min_index}_detector_min.png
+cp ${photoSourceDir}/${max_index}_detector.png ${destinationDir}/LabelledDetectorPhotos/${gen}_labelled_photos/${gen}_${max_index}_detector_max.png
+cp ${photoSourceDir}/${mid_index}_detector.png ${destinationDir}/LabelledDetectorPhotos/${gen}_labelled_photos/${gen}_${mid_index}_detector_mid.png
+cp ${photoSourceDir}/${min_index}_detector.png ${destinationDir}/LabelledDetectorPhotos/${gen}_labelled_photos/${gen}_${min_index}_detector_min.png
 #
-### Removes the remaining photos
-rm ${photoSourceDir}/*_detector.png
-#
-doubleNPOP=$((NPOP*2))
 
 # gainNum corresponds to the frequency in which we want to see the gain pattern
 # A value X corresponds to (200 MHz + 10 MHz * X) frequency
@@ -82,8 +83,11 @@ mkdir -m775 $WorkingDir/Run_Outputs/$RunName/Gain_Plots/${gen}_Gain_Plots
 
 module load python/3.7-2019.10
 
-python polar_plotter_v2.py $WorkingDir/Run_Outputs/$RunName/uan_files/${gen}_uan_files $WorkingDir/Run_Outputs/$RunName/Gain_Plots/${gen}_Gain_Plots $freqNum $doubleNPOP $gen
+echo "starting gain plots"
 
+python polar_plotter_v2.py $WorkingDir/Run_Outputs/$RunName/uan_files/${gen}_uan_files $WorkingDir/Run_Outputs/$RunName/Gain_Plots/${gen}_Gain_Plots $freqNum $NPOP $gen $SYMMETRY
+
+echo "finished gain plots"
 #
 ### Removes temporary files
 rm temp_best.csv

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/image_maker.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/image_maker.sh
@@ -64,7 +64,7 @@ echo "exp: $exp"
 
 python physicsOfResultsPUEO.py $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files $WorkingDir/Run_Outputs/$RunName/Generation_Data $max_index $exp
 
-mkdir ${destinationDir}/${gen}_detector_photos
+mkdir -p ${destinationDir}/LabelledDetectorPhotos/${gen}_labelled_photos
 mv ${photoSourceDir}/${max_index}_detector.png ${destinationDir}/${gen}_detector_photos/${gen}_${max_index}_detector_max.png
 mv ${photoSourceDir}/${mid_index}_detector.png ${destinationDir}/${gen}_detector_photos/${gen}_${mid_index}_detector_mid.png
 mv ${photoSourceDir}/${min_index}_detector.png ${destinationDir}/${gen}_detector_photos/${gen}_${min_index}_detector_min.png

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/newCombineErrors.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/newCombineErrors.py
@@ -31,12 +31,12 @@ identical_indivs = []
 
 # Load in the DNA files from the previous and current generation
 # variables are S, H, Xi, Yi, Zf, Yf, beta 
-skiprows = 8
+intro_rows = 9
 
 def read_DNA(DNA_file):
     '''Return a list of tuples containing the DNA of each individual in the population'''
     DNA_csv = pd.read_csv(DNA_file, header=None, 
-                          delimiter=',', skiprows=skiprows)
+                          delimiter=',', skiprows=intro_rows)
     DNA = {
         "S": DNA_csv.iloc[:, 0].values,
         "H": DNA_csv.iloc[:, 1].values,

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/physicsOfResultsPUEO.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/physicsOfResultsPUEO.py
@@ -33,7 +33,7 @@ parser.add_argument("indiv", help="individual number", type=int)
 parser.add_argument("energy", help="energy of neutrino", type=int)
 g = parser.parse_args()
 
-print(g.source, g.destination, g.indiv, g.energy)
+#print(g.source, g.destination, g.indiv, g.energy)
 
 libPath = "/fs/ess/PAS1960/buildingPueoSim/pueoBuilder/lib"
 #libPath = "/users/PAS1960/dylanwells1629/buildingPueoSim/pueoBuilder/lib"
@@ -83,7 +83,6 @@ def getFiles(source, energy, indiv):
     # The root files will be named IceFinal_$genNum_$indiv_$seed.root
 
     root = source
-    print(root)
     all_tree_pattern = "IceFinal_allTree_*_{}_*.root".format(indiv)
     pass_tree_pattern = "IceFinal_passTree_*_{}_*_0.root".format(indiv)
 
@@ -92,7 +91,7 @@ def getFiles(source, energy, indiv):
         j = 0
         for name in files:
             if fnmatch(name, all_tree_pattern):
-                print(os.path.join(path, name))
+                #print(os.path.join(path, name))
                 
                 try:
                     # Open the root file and assign the trees to variables
@@ -102,7 +101,7 @@ def getFiles(source, energy, indiv):
 
                     allTree = IceFinalFile.allTree
                     allEvents = allTree.GetEntries()
-                    print(allEvents)
+                    #print(allEvents)
                     TotalEvents[energy].append(allEvents)
                     
                 except Exception as e:
@@ -110,7 +109,7 @@ def getFiles(source, energy, indiv):
                     continue
                 
             elif fnmatch(name, pass_tree_pattern):
-                print(os.path.join(path, name))
+                #print(os.path.join(path, name))
                 
                 try:    
                     
@@ -122,7 +121,7 @@ def getFiles(source, energy, indiv):
                     
                     nuWeights = []
                     nuPasses = []
-                    print(passEvents)
+                    #print(passEvents)
                     
                 except Exception as e:
                     print("Error opening file", e)
@@ -199,7 +198,7 @@ getFiles(g.source, g.energy, g.indiv)
 
 
 
-print("Plotting")
+print("Plotting PORP")
 ### Plotting ###
 mpl.rcParams['text.usetex'] = True
 # colorblind friendly colors

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/polar_plotter_v2.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/polar_plotter_v2.py
@@ -35,12 +35,17 @@ parser.add_argument("destination", help="Name of destination folder from home di
 parser.add_argument("freq_num", help="Frequency number (1-60) to plot", type=int)
 parser.add_argument("NPOP", help="Number of individuals in a generation (ex: 10)", type=int)
 parser.add_argument("gen", help="Generation number (ex: 0)", type=int)
+parser.add_argument("SYMMETRY", help="Symmetry of antenna (ex: 2)", type=int)
 g=parser.parse_args()
 
+if g.SYMMETRY == 0:
+    npop = g.NPOP * 2
+else:
+    npop = g.NPOP
 ## Loop over files
 # Declare list for each file's gain list
 gains = []
-for individual in range(0, g.NPOP):
+for individual in range(1, npop+1):
 	## Open the file to read
 	## NOTE: Looks for folder in source that contains a folder with name "gen_#"
 	with open(g.source + "/" + str(individual) + "/" + str(g.gen) + "_" + str(individual) + "_" + str(g.freq_num) + ".uan", "r") as f:
@@ -78,9 +83,14 @@ f3 = open("temp_worst.csv", "r")
 
 ### Saves these indices to variables
 ### Each individual has 2 files, so the index is multiplied by 2 and subtracted by 1
-max_index = (int(f1.readline())*2)-1
-mid_index = (int(f2.readline())*2)-1
-min_index = (int(f3.readline())*2)-1
+if g.SYMMETRY == 0:
+	max_index = (int(f1.readline())*2)-1
+	mid_index = (int(f2.readline())*2)-1
+	min_index = (int(f3.readline())*2)-1
+else:  
+	max_index = (int(f1.readline()))-1
+	mid_index = (int(f2.readline()))-1
+	min_index = (int(f3.readline()))-1
 
 ### Closes the temporary files
 f1.close()

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/polar_plotter_v2.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/polar_plotter_v2.py
@@ -33,21 +33,21 @@ parser = argparse.ArgumentParser()
 parser.add_argument("source", help="Name of source folder from home directory", type=str)
 parser.add_argument("destination", help="Name of destination folder from home directory", type=str)
 parser.add_argument("freq_num", help="Frequency number (1-60) to plot", type=int)
-parser.add_argument("NPOP", help="Number of individuals in a generation (ex: 10)", type=int)
+parser.add_argument("npop", help="Number of individuals in a generation (ex: 10)", type=int)
 parser.add_argument("gen", help="Generation number (ex: 0)", type=int)
-parser.add_argument("SYMMETRY", help="Symmetry of antenna (ex: 2)", type=int)
+parser.add_argument("symmetry", help="Symmetry of antenna (ex: 2)", type=int)
 g=parser.parse_args()
 
 sims_per_antenna = 1
-if g.SYMMETRY == 0:
+if g.symmetry == 0:
     sims_per_antenna = 2
 
-npop = g.NPOP * sims_per_antenna
+pop_size = g.npop * sims_per_antenna
 
 ## Loop over files
 # Declare list for each file's gain list
 gains = []
-for individual in range(1, npop+1):
+for individual in range(1, pop_size+1):
 	## Open the file to read
 	## NOTE: Looks for folder in source that contains a folder with name "gen_#"
 	with open(g.source + "/" + str(individual) + "/" + str(g.gen) + "_" + str(individual) + "_" + str(g.freq_num) + ".uan", "r") as f:
@@ -128,7 +128,7 @@ plt.title("Antennas at Frequency number {} MHz (Vertical Polarization)".format(r
 plt.savefig(g.destination + "/polar_plot_" + str(round(200 + 10 * (g.freq_num-1), 3)) + "_Vpol.png")
 
 ## plot the second antenna ###################
-if g.SYMMETRY == 0:
+if g.symmetry == 0:
 	## Declare a figure
 	fig, ax = plt.subplots(subplot_kw={'projection': 'polar'}, figsize = (10, 8))
 	ax.set_theta_zero_location("N")

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/polar_plotter_v2.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/polar_plotter_v2.py
@@ -38,10 +38,12 @@ parser.add_argument("gen", help="Generation number (ex: 0)", type=int)
 parser.add_argument("SYMMETRY", help="Symmetry of antenna (ex: 2)", type=int)
 g=parser.parse_args()
 
+sims_per_antenna = 1
 if g.SYMMETRY == 0:
-    npop = g.NPOP * 2
-else:
-    npop = g.NPOP
+    sims_per_antenna = 2
+
+npop = g.NPOP * sims_per_antenna
+
 ## Loop over files
 # Declare list for each file's gain list
 gains = []
@@ -83,14 +85,9 @@ f3 = open("temp_worst.csv", "r")
 
 ### Saves these indices to variables
 ### Each individual has 2 files, so the index is multiplied by 2 and subtracted by 1
-if g.SYMMETRY == 0:
-	max_index = (int(f1.readline())*2)-1
-	mid_index = (int(f2.readline())*2)-1
-	min_index = (int(f3.readline())*2)-1
-else:  
-	max_index = (int(f1.readline()))-1
-	mid_index = (int(f2.readline()))-1
-	min_index = (int(f3.readline()))-1
+max_index = int(f1.readline()) * sims_per_antenna - 1
+mid_index = int(f2.readline()) * sims_per_antenna - 1
+min_index = int(f3.readline()) * sims_per_antenna - 1
 
 ### Closes the temporary files
 f1.close()
@@ -123,7 +120,7 @@ for i in range(len(indiv_list)):
     
     ### Plots the gain pattern for one individual
 	LabelName = "{}".format(str(rank_list[i]) + ": " + str(int((indiv_list[i]+1)/2)))
-	ax.plot(zenith_angles, gains[indiv_list[i]], color = colors[i], linestyle = linestyles[i], alpha = 0.6, linewidth=3, label = LabelName)
+	ax.plot(zenith_angles, gains[indiv_list[i]], color = colors[i%3], linestyle = linestyles[i%3], alpha = 0.6, linewidth=3, label = LabelName)
 
 ### Creates legend and title for plot, then saves as an image
 ax.legend(loc = 'lower right', bbox_to_anchor=(1.27, -0.12), title='Individual Number (Gen ' + str(g.gen)+ ')', fontsize=17)
@@ -131,21 +128,21 @@ plt.title("Antennas at Frequency number {} MHz (Vertical Polarization)".format(r
 plt.savefig(g.destination + "/polar_plot_" + str(round(200 + 10 * (g.freq_num-1), 3)) + "_Vpol.png")
 
 ## plot the second antenna ###################
+if g.SYMMETRY == 0:
+	## Declare a figure
+	fig, ax = plt.subplots(subplot_kw={'projection': 'polar'}, figsize = (10, 8))
+	ax.set_theta_zero_location("N")
+	ax.set_rlabel_position(225)
+	ax.tick_params(axis='both', which='major', labelsize=11.5)
 
-## Declare a figure
-fig, ax = plt.subplots(subplot_kw={'projection': 'polar'}, figsize = (10, 8))
-ax.set_theta_zero_location("N")
-ax.set_rlabel_position(225)
-ax.tick_params(axis='both', which='major', labelsize=11.5)
+	### Iterates over the three individuals above (best, worst, and mid performing)
+	for i in range(len(indiv_list2)):
+		
+		### Plots the gain pattern for one individual
+		LabelName = "{}".format(str(rank_list[i]) + ": " + str(int((indiv_list2[i]+1)/2)))
+		ax.plot(zenith_angles, gains[indiv_list2[i]], color = colors[i%3], linestyle = linestyles[i%3], alpha = 0.6, linewidth=3, label = LabelName)
 
-### Iterates over the three individuals above (best, worst, and mid performing)
-for i in range(len(indiv_list2)):
-    
-    ### Plots the gain pattern for one individual
-	LabelName = "{}".format(str(rank_list[i]) + ": " + str(int((indiv_list2[i]+1)/2)))
-	ax.plot(zenith_angles, gains[indiv_list2[i]], color = colors[i], linestyle = linestyles[i], alpha = 0.6, linewidth=3, label = LabelName)
-
-### Creates legend and title for plot, then saves as an image
-ax.legend(loc = 'lower right', bbox_to_anchor=(1.27, -0.12), title='Individual Number (Gen ' + str(g.gen)+ ')', fontsize=17)
-plt.title("Antennas at Frequency number {} MHz (Horizontal Polarization)".format(round(200 + 10*(g.freq_num-1), 6)), fontsize = 18)
-plt.savefig(g.destination + "/polar_plot_" + str(round(200 + 10 * (g.freq_num-1), 3)) + "_Hpol.png")
+	### Creates legend and title for plot, then saves as an image
+	ax.legend(loc = 'lower right', bbox_to_anchor=(1.27, -0.12), title='Individual Number (Gen ' + str(g.gen)+ ')', fontsize=17)
+	plt.title("Antennas at Frequency number {} MHz (Horizontal Polarization)".format(round(200 + 10*(g.freq_num-1), 6)), fontsize = 18)
+	plt.savefig(g.destination + "/polar_plot_" + str(round(200 + 10 * (g.freq_num-1), 3)) + "_Hpol.png")

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/polar_plotter_v2.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/polar_plotter_v2.py
@@ -40,7 +40,7 @@ g=parser.parse_args()
 ## Loop over files
 # Declare list for each file's gain list
 gains = []
-for individual in range(1, g.NPOP+1):
+for individual in range(0, g.NPOP):
 	## Open the file to read
 	## NOTE: Looks for folder in source that contains a folder with name "gen_#"
 	with open(g.source + "/" + str(individual) + "/" + str(g.gen) + "_" + str(individual) + "_" + str(g.freq_num) + ".uan", "r") as f:

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/rootAnalysis.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/rootAnalysis.py
@@ -57,7 +57,7 @@ def EffectiveVolume2(thisColor,thisLabel):
         for name in files:
             #print(name)
             if fnmatch(name,allTreePattern):
-                print(os.path.join(path,name))
+                #print(os.path.join(path,name))
                
                 # this_energy is leftover from Will's code,
                 # I'll keep it in case we ever decide to simulate
@@ -84,7 +84,7 @@ def EffectiveVolume2(thisColor,thisLabel):
                 #If you don't load libraries (or if you can't), you can load events with, e.g. allTree.GetLeaf("eventSummary.neutrino.flavor").GetValue()
                 
             elif fnmatch(name,passTreePattern):
-                print(os.path.join(path,name))
+                #print(os.path.join(path,name))
                 
                 try: 
                     fileName = os.path.join(path,name)
@@ -176,20 +176,21 @@ def EffectiveVolume2(thisColor,thisLabel):
 
     with open("{}/{}_pueoOut.csv".format(g.opath, g.gen), 'a') as f:
         f.write("{},{},{},{}\n".format(g.indiv, effective_V[0], effective_V_p[0], effective_V_m[0]))
-        print("Writing to:", "{}/{}_pueoOut.csv".format(g.opath, g.gen))
+        #print("Writing to:", "{}/{}_pueoOut.csv".format(g.opath, g.gen))
     
     with open("{}/{}_fitnessScores.csv".format(g.opath, g.gen), 'a') as f:
         f.write("{}\n".format(effective_V[0]))
-        print("Writing to:", "{}/{}_fitnessScores.csv".format(g.opath, g.gen))
+        #print("Writing to:", "{}/{}_fitnessScores.csv".format(g.opath, g.gen))
     
     with open("{}/{}_vEffectives.csv".format(g.opath, g.gen), 'a') as f:
         f.write("{}\n".format(effective_V[0]))
-        print("Writing to:", "{}/{}_vEffectives.csv".format(g.opath, g.gen))
+       #print("Writing to:", "{}/{}_vEffectives.csv".format(g.opath, g.gen))
         
     with open("{}/{}_errorBars.csv".format(g.opath, g.gen), 'a') as f:
         f.write("{},{}\n".format(effective_V_p[0], effective_V_m[0]))
-        print("Writing to:", "{}/{}_errorBars.csv".format(g.opath, g.gen))
+        #print("Writing to:", "{}/{}_errorBars.csv".format(g.opath, g.gen))
 
+    print("Wrote individual {} fitness".format(g.indiv))
 
 def AddErrors(all_weights):
     bin_num = 10

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/rootAnalysis.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/rootAnalysis.py
@@ -55,7 +55,7 @@ def EffectiveVolume2(thisColor,thisLabel):
 
     for path, subdirs, files in os.walk(root):
         for name in files:
-            print(name)
+            #print(name)
             if fnmatch(name,allTreePattern):
                 print(os.path.join(path,name))
                

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/GPU_XF_Job.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/GPU_XF_Job.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 ## We want to submit the XFsolver as a job array to GPUs
 ## We'll submit up to 4 at a time (based on number of XF keys)
 ## Here's the submission command:
@@ -9,9 +8,9 @@
 #SBATCH -N 1
 #SBATCH -n 40
 #SBATCH -G 2
-#SBATCH --output=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Run_Outputs/%x/XF_Outputs/XF_%a.output
-#SBATCH --error=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Run_Outputs/%x/XF_Errors/XF_%a.error
-##SBATCH --mem-per-gpu=178gb
+#SBATCH --output=Run_Outputs/%x/XF_Outputs/XF_%a.output
+#SBATCH --error=Run_Outputs/%x/XF_Errors/XF_%a.error
+#SBATCH --mem-per-gpu=178gb
 
 ## make sure we're in the right directory
 cd $WorkingDir

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/GPU_XF_Job.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/GPU_XF_Job.sh
@@ -21,7 +21,12 @@ module load cuda
 
 ## We need to get the individual number
 ## This will be based on the number in the array
-individual_number=$((${gen}*${NPOP}*2+${SLURM_ARRAY_TASK_ID}))
+if [ $SYMMETRY -eq 0 ]
+then
+	individual_number=$((${gen}*${NPOP}*2+${SLURM_ARRAY_TASK_ID}))
+else
+	individual_number=$((${gen}*${NPOP}+${SLURM_ARRAY_TASK_ID}))
+fi
 
 ## Based on the individual number, we need the right parent directory
 ## This involves checking the individual number being submitted

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array.sh
@@ -26,7 +26,7 @@ seed=$(($((${SLURM_ARRAY_TASK_ID}-1))%${Seeds}+1))
 
 # run number is the unique identifier for each pueoSim Process
 # 40 processes are run per generation per seed
-run_num=$(((NPOP * gen + num) * 1000 + seed * 40))
+run_num=$(((NPOP * gen + num) * 1000 + seed * threads))
 
 
 # set up environment

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array.sh
@@ -38,13 +38,13 @@ cp pueoBuilder/build/components/pueoSim/simulatePueo $TMPDIR/simulatePueo
 cp pueoBuilder/components/pueoSim/config/pueo.conf $TMPDIR/pueo.conf
 
 cd $TMPDIR
-touch pueoout.txt
 
 echo "Running PSIM"
 for ((i=$run_num; i<$((threads + run_num)); i++))
 do
     # Run 40 processes of pueoSim 
-    ./simulatePueo -i pueo.conf -o $TMPDIR -r $i -n $NNT -e $Exp > pueoout.txt &
+    touch pueoout${i}.txt
+    ./simulatePueo -i pueo.conf -o $TMPDIR -r $i -n $NNT -e $Exp > pueoout${i}.txt &
 done
 
 echo "started PSIMs"
@@ -57,10 +57,9 @@ do
     mv $TMPDIR/run${i}/IceFinal_${i}_skimmed.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_skimmed_${gen}_${num}_${i}.root
     mv $TMPDIR/run${i}/IceFinal_${i}_allTree.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_allTree_${gen}_${num}_${i}.root
     mv $TMPDIR/run${i}/IceFinal_${i}_passTree0.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_passTree_${gen}_${num}_${i}_0.root
+    mkdir -p -m775 $PSIMDIR/outputs/${RunName}/${gen}_outputs/${SLURM_ARRAY_TASK_ID}/run${run_num}
+    mv peuoout${i}.txt $PSIMDIR/outputs/${RunName}/${gen}_outputs/${SLURM_ARRAY_TASK_ID}/run${run_num}
 done
-
-# move pueoout for debugging
-mv peuoout.txt $PSIMDIR/outputs/${RunName}/${gen}_outputs/${SLURM_ARRAY_TASK_ID}/run${run_num}
 
 echo $gen > $TMPDIR/${num}_${seed}.txt
 echo $num >> $TMPDIR/${num}_${seed}.txt

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array.sh
@@ -3,11 +3,11 @@
 ## Here's the command:
 ## sbatch --array=1-NPOP*SEEDS%max --export=ALL,(variables) PueoCall_Array.sh
 #SBATCH -A PAS1960
-#SBATCH -t 10:00:00
+#SBATCH -t 03:00:00
 #SBATCH -N 1
 #SBATCH -n 40
-#SBATCH --output=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Run_Outputs/%x/PUEO_Outputs/PUEOsim_%a.output
-#SBATCH --error=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Run_Outputs/%x/PUEO_Errors/PUEOsim_%a.error
+#SBATCH --output=Run_Outputs/%x/PUEO_Outputs/PUEOsim_%a.output
+#SBATCH --error=Run_Outputs/%x/PUEO_Errors/PUEOsim_%a.error
 
 #variables
 #gen=$1
@@ -54,9 +54,9 @@ echo "PSIMS finished"
 # move the root files
 for ((i=$run_num; i<$((threads + run_num)); i++))
 do
-    mv $TMPDIR/run${i}/IceFinal_${i}_skimmed.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_skimmed_${gen}_${num}_${seed}.root
-    mv $TMPDIR/run${i}/IceFinal_${i}_allTree.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_allTree_${gen}_${num}_${seed}.root
-    mv $TMPDIR/run${i}/IceFinal_${i}_passTree0.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_passTree_${gen}_${num}_${seed}_0.root
+    mv $TMPDIR/run${i}/IceFinal_${i}_skimmed.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_skimmed_${gen}_${num}_${i}.root
+    mv $TMPDIR/run${i}/IceFinal_${i}_allTree.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_allTree_${gen}_${num}_${i}.root
+    mv $TMPDIR/run${i}/IceFinal_${i}_passTree0.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_passTree_${gen}_${num}_${i}_0.root
 done
 
 # move pueoout for debugging

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array.sh
@@ -5,7 +5,7 @@
 #SBATCH -A PAS1960
 #SBATCH -t 10:00:00
 #SBATCH -N 1
-#SBATCH -n 8
+#SBATCH -n 40
 #SBATCH --output=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Run_Outputs/%x/PUEO_Outputs/PUEOsim_%a.output
 #SBATCH --error=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Run_Outputs/%x/PUEO_Errors/PUEOsim_%a.error
 
@@ -19,67 +19,56 @@
 #NNT=$7
 #Exp=$8
 
-#source /fs/ess/PAS1960/BiconeEvolutionOSC/new_root/new_root_setup.sh
-
-source /fs/ess/PAS1960/buildingPueoSim/set_env.sh
-
-cd $PSIMDIR
-cd outputs/${gen}_outputs
-mkdir -m775 $SLURM_ARRAY_TASK_ID
-cd ../..
-# Need to change IceMC to read in the correct gain files for each run 
-
-
-#this is the command in the XF script although I don't know if we can pass in variables from that script
-#into this one like i and WorkingDir
-#if in the job call we have 
+threads=40
 
 num=$(($((${SLURM_ARRAY_TASK_ID}-1))/${Seeds}+1))
 seed=$(($((${SLURM_ARRAY_TASK_ID}-1))%${Seeds}+1))
 
-run_num=$(((NPOP * gen + num) * 1000 + seed))
+# run number is the unique identifier for each pueoSim Process
+# 40 processes are run per generation per seed
+run_num=$(((NPOP * gen + num) * 1000 + seed * 40))
 
-echo a_${num}_${seed}.txt
 
-chmod -R 777 ${PSIMDIR}/outputs/${gen}_outputs/
+# set up environment
+cd $PSIMDIR
+source set_env.sh
 
-#./icemc -i ${PSIMDIR}/components/icemc/setup.conf -o outputs/ -r "_${gen}_${num}" > $TMPDIR/
-
-./pueoBuilder/build/components/pueoSim/simulatePueo -i pueo.conf -o ${PSIMDIR}/outputs/${gen}_outputs/$SLURM_ARRAY_TASK_ID -r $run_num -n $NNT -e $Exp > $TMPDIR/out.txt
-
-cd $TMPDIR
-echo "After done running PUEOsim"
-pwd
-ls -alrt
-mv out.txt $PSIMDIR/outputs/${gen}_outputs/${SLURM_ARRAY_TASK_ID}/run${run_num}
-cd $PSIMDIR/outputs/${gen}_outputs/${SLURM_ARRAY_TASK_ID}/run${run_num}
-grep -s "Effective volume: " out.txt | tail -n1 > veff_${run_num}.csv
-grep -s "Effective volume: " out.txt
-ls -alrt
-cat veff_${run_num}.csv >> $WorkingDir/Run_Outputs/$RunName/veff_${gen}_${num}.csv
-echo ${seed} >> $WorkingDir/Run_Outputs/$RunName/${gen}_counts.txt #might need to take this in to account to see which veff corresponds to which in the veff file
-# PueoSim v1.1.0 outputs 3 IceFinal files for each run
-mv IceFinal_${run_num}_allTree.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_allTree_${gen}_${num}_${seed}.root
-mv IceFinal_${run_num}_skimmed.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_skimmed_${gen}_${num}_${seed}.root
-mv IceFinal_${run_num}_passTree0.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_passTree_${gen}_${num}_${seed}_0.root
-# remove the rest of the files (Each takes up multiple GBs)
-rm *.root
-cd ..
-#rm -r run${run_num}
+# copy simulation exe to TMPDIR
+cp pueoBuilder/build/components/pueoSim/simulatePueo $TMPDIR/simulatePueo
+cp pueoBuilder/components/pueoSim/config/pueo.conf $TMPDIR/pueo.conf
 
 cd $TMPDIR
-mv * $WorkingDir/Antenna_Performance_Metric 
-#cd $WorkingDir/Run_Outputs/$RunName/AraSimFlags
-#echo ${num}_${Seeds} > ${num}_${Seeds}.txt
+touch pueoout.txt
+
+echo "Running PSIM"
+for ((i=$run_num; i<$((threads + run_num)); i++))
+do
+    # Run 40 processes of pueoSim 
+    ./simulatePueo -i pueo.conf -o $TMPDIR -r $i -n $NNT -e $Exp > pueoout.txt &
+done
+
+echo "started PSIMs"
+wait
+echo "PSIMS finished"
+
+# move the root files
+for ((i=$run_num; i<$((threads + run_num)); i++))
+do
+    mv $TMPDIR/run${i}/IceFinal_${i}_skimmed.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_skimmed_${gen}_${num}_${seed}.root
+    mv $TMPDIR/run${i}/IceFinal_${i}_allTree.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_allTree_${gen}_${num}_${seed}.root
+    mv $TMPDIR/run${i}/IceFinal_${i}_passTree0.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/IceFinal_passTree_${gen}_${num}_${seed}_0.root
+done
+
+# move pueoout for debugging
+mv peuoout.txt $PSIMDIR/outputs/${RunName}/${gen}_outputs/${SLURM_ARRAY_TASK_ID}/run${run_num}
+
 echo $gen > $TMPDIR/${num}_${seed}.txt
 echo $num >> $TMPDIR/${num}_${seed}.txt
 echo $seed >> $TMPDIR/${num}_${seed}.txt
 
-mv * $WorkingDir/Run_Outputs/$RunName/PUEOFlags
+# move the flag file
+mv $TMPDIR/${num}_${seed}.txt $WorkingDir/Run_Outputs/$RunName/PUEOFlags
 
-#cp veff_${gen}_${num}.csv.* veff_${gen}_${num}.csv
-
-# now do the flag files
 cd $WorkingDir/Run_Outputs/$RunName/PUEOFlags
 
 cp ${num}_${seed}.txt.* ${num}_${seed}.txt

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_A/Part_A.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_A/Part_A.sh
@@ -37,12 +37,14 @@ else
 fi
 
 cp Generation_Data/generationDNA.csv Run_Outputs/$RunName/${gen}_generationDNA.csv
-mv Generation_Data/generators.csv Run_Outputs/$RunName/${gen}_generators.csv
+
+# redirect stderr to /dev/null to avoid error messages when the file doesn't exist
+mv Generation_Data/generators.csv Run_Outputs/$RunName/${gen}_generators.csv 2>/dev/null
 if [ $gen -gt 0 ]
 then
         mv Generation_Data/parents.csv Run_Outputs/$RunName/${gen}_parents.csv
-        mv Generation_Data/genes.csv Run_Outputs/$RunName/${gen}_genes.csv
-        mv Generation_Data/mutations.csv Run_Outputs/$RunName/${gen}_mutations.csv
+        mv Generation_Data/genes.csv Run_Outputs/$RunName/${gen}_genes.csv 2>/dev/null
+        mv Generation_Data/mutations.csv Run_Outputs/$RunName/${gen}_mutations.csv 2>/dev/null
 fi
 
 

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_A/Part_A_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_A/Part_A_PUEO.sh
@@ -28,8 +28,9 @@ cd $WorkingDir
 g++ -std=c++11 GA/Shared-Code/GA/SourceFiles/New_GA.cpp -o GA/New_GA.exe
 ./GA/New_GA.exe PUEO $gen $NPOP $rank_no $roulette_no $tournament_no $reproduction_no $crossover_no $mutationRate $sigma
 
+cp generationDNA.csv Generation_Data/generationDNA.csv
 cp Generation_Data/generationDNA.csv Run_Outputs/$RunName/Generation_Data/${gen}_generationDNA.csv
-mv Generation_Data/generators.csv Run_Outputs/$RunName/Generation_Data/${gen}_generators.csv
+mv Generation_Data/generators.csv Run_Outputs/$RunName/Generation_Data/${gen}_generators.csv 2>/dev/null
 
 if [ $gen -gt 0 ]
 then

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_A/Part_A_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_A/Part_A_PUEO.sh
@@ -34,6 +34,7 @@ mv Generation_Data/generators.csv Run_Outputs/$RunName/Generation_Data/${gen}_ge
 
 if [ $gen -gt 0 ]
 then
+	cp parents.csv Generation_Data/parents.csv
 	mv Generation_Data/parents.csv Run_Outputs/$RunName/Generation_Data/${gen}_parents.csv
 fi
 chmod -R 775 Generation_Data/

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B_PUEO.sh
@@ -216,7 +216,7 @@ fi
 ## We'll make the run name the job name
 ## This way, we can use it in the SBATCH commands
 #I think this should work for PUEO too
-sbatch --array=1-${XFCOUNT}%${batch_size} --export=ALL,WorkingDir=$WorkingDir,RunName=$RunName,XmacrosDir=$XmacrosDir,XFProj=$XFProj,NPOP=$NPOP,indiv=$individual_number,indiv_dir=$indiv_dir,gen=${gen} --job-name=${RunName} Batch_Jobs/GPU_XF_Job.sh
+sbatch --array=1-${XFCOUNT}%${batch_size} --export=ALL,WorkingDir=$WorkingDir,RunName=$RunName,XmacrosDir=$XmacrosDir,XFProj=$XFProj,NPOP=$NPOP,indiv=$individual_number,indiv_dir=$indiv_dir,gen=${gen},SYMMETRY=$SYMMETRY --job-name=${RunName} Batch_Jobs/GPU_XF_Job.sh
 
 
 

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B_PUEO.sh
@@ -142,7 +142,25 @@ fi
 
 #we cat things into the simulation_PEC.xmacro file, so we can just echo the list to it before catting other files
 
-cat PUEO_skeleton.txt >> simulation_PEC.xmacro
+#cat PUEO_skeleton.txt >> simulation_PEC.xmacro
+# Would like to just be able to import to XF with a command in the xmacros
+# And then I only need to cat in a handful of scripts into simulation_PEC.xmacro
+# According Walter Janusz at Remcom, this isn't possible yet. So we'll just have to 
+# 	concatenate everything into a fil ourselves
+
+cat headerPUEO.xmacro >> simulation_PEC.xmacro
+cat functionCallsPUEO_reordered.xmacro >> simulation_PEC.xmacro
+#cat functionCallsPUEO.xmacro >> simulation_PEC.xmacro
+cat buildWalls.xmacro >> simulation_PEC.xmacro
+cat buildRidges.xmacro >> simulation_PEC.xmacro
+cat CreatePEC.xmacro >> simulation_PEC.xmacro
+cat CreateAntennaSource.xmacro >> simulation_PEC.xmacro
+cat CreateGrid.xmacro >> simulation_PEC.xmacro
+cat CreateSensors.xmacro >> simulation_PEC.xmacro
+cat CreateAntennaSimulationData.xmacro >> simulation_PEC.xmacro
+cat QueueSimulation.xmacro >> simulation_PEC.xmacro
+cat MakeImage.xmacro >> simulation_PEC.xmacro
+
 # Replace the number of times we simulate based on the symmetry
 # Annoying because we need to count to the the opposite of $SYMMETRY
 if [ $SYMMETRY -eq 1 ]
@@ -151,8 +169,7 @@ then
 else
 	vim -c ':%s/SYMMETRY/1' + -c ':wq!' simulation_PEC.xmacro
 fi
-#cat simulationPECmacroskeleton_PUEO.txt >> simulation_PEC.xmacro
-#cat simulationPECmacroskeleton2_PUEO.txt >> simulation_PEC.xmacro
+
 
 #we need to change the gridsize by the same factor as the antenna size
 #the gridsize in the macro skeleton is currently set to 0.1

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B_job2_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B_job2_PUEO.sh
@@ -110,7 +110,7 @@ chmod 775 *
 mkdir -m775 $WorkingDir/Run_Outputs/$RunName/Antenna_Images/${gen}
 for i in `seq $NPOP`
 do
-	mv ${i}_detector.png $WorkingDir/Run_Outputs/$RunName/Antenna_Images/${gen}/${i}_detector.png
+	mv antenna_images/${i}_detector.png $WorkingDir/Run_Outputs/$RunName/Antenna_Images/${gen}/${i}_detector.png
 done
 
 #chmod -R 777 /fs/ess/PAS1960/BiconeEvolutionOSC/BiconeEvolution/

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_C/Part_C_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_C/Part_C_PUEO.sh
@@ -21,11 +21,11 @@ cd $WorkingDir/Test_Outputs
 ## We need to remove the files in the Test_Outputs directory
 ## I'm doing it very carefully to avoid deleting files in a different location
 ##	in the event $WorkindDir has some issue
-rm vv*
-rm hh*
-rm vh*
-rm hv*
-cd ../Antenna_Performance_Metric
+rm vv* 2>/dev/null
+rm hh* 2>/dev/null
+rm vh* 2>/dev/null
+rm hv* 2>/dev/null
+cd $WorkingDir/Antenna_Performance_Metric
 
 chmod -R 777 $WorkingDir/Antenna_Performance_Metric
 if [ $SYMMETRY -eq 0 ]
@@ -42,3 +42,5 @@ do
 	cp $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/hv_0_toyon ../Test_Outputs/hv_0_${gen}_${i}
 	cp $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/vh_0_toyon ../Test_Outputs/vh_0_${gen}_${i}
 done
+
+chmod -R 777 $WorkingDir/Test_Outputs

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_C/Part_C_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_C/Part_C_PUEO.sh
@@ -12,6 +12,7 @@ RunName=$3
 gen=$4
 indiv=$5
 SYMMETRY=$6
+PSIMDIR=$7
 #chmod -R 777 /fs/ess/PAS1960/BiconeEvolutionOSC/BiconeEvolution/
 
 module load python/3.7-2019.10
@@ -38,6 +39,6 @@ fi
 ## Temporary fix for cross-pols being low!!!
 for i in `seq 1 $NPOP`
 do
-	cp /fs/ess/PAS1960/buildingPueoSim/pueoBuilder/components/pueoSim/data/antennas/hv_0_toyon ../Test_Outputs/hv_0_${gen}_${i}
-	cp /fs/ess/PAS1960/buildingPueoSim/pueoBuilder/components/pueoSim/data/antennas/vh_0_toyon ../Test_Outputs/vh_0_${gen}_${i}
+	cp $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/hv_0_toyon ../Test_Outputs/hv_0_${gen}_${i}
+	cp $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/vh_0_toyon ../Test_Outputs/vh_0_${gen}_${i}
 done

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_D/Part_D1_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_D/Part_D1_PUEO.sh
@@ -32,6 +32,8 @@ mkdir -m775 Run_Outputs/${RunName}/Root_Files/${gen}_Root_Files
 mkdir -m775 Run_Outputs/${RunName}/uan_files/${gen}_uan_files
 mkdir -m775 ${PSIMDIR}/outputs/${RunName}/${gen}_outputs
 
+chmod -R 777 $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated/* 2>/dev/null
+
 #Move the gain files into the correct place for PSIM to read them in
 for i in `seq 1 $NPOP`
 do
@@ -45,6 +47,8 @@ do
 	cp Test_Outputs/vv_el_${gen}_${i} $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated/vv_el_Toyon${run_num}
 	cp Test_Outputs/vv_az_${gen}_${i} $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated/vv_az_Toyon${run_num}
 done
+
+chmod -R 777 $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated/* 2>/dev/null
 
 #record the gain data
 cp Test_Outputs/* $XFProj/XF_models_${gen}/

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_D/Part_D1_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_D/Part_D1_PUEO.sh
@@ -1,11 +1,11 @@
 ##########   IceMC Execution (D)  ################################################################################################################## 
 #
 #
-#       1. Moves each .dat file individually into a folder that IceMC can access while changing to file that IceMC can use
+#       1. Moves the gain patters for each antenna into the folder pueoSim accesses
 #
 #       2. For each individual ::
-#           I. Run IceMC for that file
-#           III. Moves the IceMC output into the Antenna_Performance_Metric folder
+#           I. Run pueoSim (Seeds * 40) times for each antenna
+#           II. Move the outputted root files to the Root_Files directory
 #
 #
 ################################################################################################################################################## 
@@ -24,16 +24,13 @@ XFCOUNT=${11}
 SpecificSeed=32000
 
 echo "Entering Part D1 PUEO!"
-echo $XFProj
+
+# Making directories
 cd $WorkingDir
-cd $XFProj
-pwd
-mkdir -m775 XF_models_${gen}
-cd ../Root_Files
-mkdir -m775 ${gen}_Root_Files
-cd $PSIMDIR/outputs
-mkdir -m775 ${gen}_outputs
-cd $WorkingDir
+mkdir -m775 ${XFProj}/XF_models_${gen}
+mkdir -m775 Run_Outputs/${RunName}/Root_Files/${gen}_Root_Files
+mkdir -m775 Run_Outputs/${RunName}/uan_files/${gen}_uan_files
+mkdir -m775 ${PSIMDIR}/outputs/${RunName}/${gen}_outputs
 
 #Move the gain files into the correct place for PSIM to read them in
 for i in `seq 1 $NPOP`
@@ -48,6 +45,7 @@ do
 	cp Test_Outputs/vv_el_${gen}_${i} $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated/vv_el_Toyon${run_num}
 	cp Test_Outputs/vv_az_${gen}_${i} $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated/vv_az_Toyon${run_num}
 done
+
 #record the gain data
 cp Test_Outputs/* $XFProj/XF_models_${gen}/
 
@@ -57,81 +55,25 @@ then
 	mkdir -m775 Run_Outputs/${RunName}/PUEO_Errors
 fi
 
-
-cd Antenna_Performance_Metric
-
-echo "Resuming..."
-cd $PSIMDIR
-
-
-#Let's make sure we're sourcing the correct files
-#source /fs/ess/PAS1960/BiconeEvolutionOSC/new_root/new_root_setup.sh
-#put a copy of this in the repository
-#Probably change this in the future
 source $PSIMDIR/set_env.sh
 
-#If we're doing a real run, we only need to change the setup.txt file once
-#Although we need to be careful, since maybe eventually we'll want to run multiple times at once?
 if [ $DEBUG_MODE -eq 0 ]
 then
-
-	#Shouldn't need this as we input these as paramaters into the simulatePueo call
-	#sed -e "s/Number of neutrinos: 200/Number of neutrinos: ${NNT}/" -e "s/Energy exponent: 20/Energy exponent: $exp/" ${PSIMDIR}/pueoBuilder/components/pueoSim/config/pueo.conf > ${PSIMDIR}/pueoBuilder/components/pueoSim/config/setup.conf
-	
-	# Now we just need to run IceMC from the setup file
-	# Instead of a for loop, we can use a single command
-	# We need the jobs to go form 1 to NPOP*NSEEDS
-	# For the job name, make it the RunName
-	# This will help for directing the output/error files
 	cd $WorkingDir
 	numJobs=$((NPOP*Seeds))
-	maxJobs=252 #for now, maybe make this a variable in the main script
+	maxJobs=252 
+	# Each job will simulate pueosim 40 times for NNT neutrinos each
 	sbatch --array=1-${numJobs}%${maxJobs} --export=ALL,gen=$gen,WorkingDir=$WorkingDir,RunName=$RunName,Seeds=$Seeds,PSIMDIR=$PSIMDIR,NPOP=$NPOP,NNT=$NNT,Exp=$exp --job-name=${RunName} Batch_Jobs/PueoCall_Array.sh
-	cd $PSIMDIR
 
-# If we're testing with the seed, use DEBUG_MODE=1
-#For now DEBUG mode doesn't work for PUEO
+# Currently Debug=1 is not implemented for PUEO @todo
 else
-	for i in `seq 1 $NPOP`
-	do
-		for j in `seq 1 $Seeds`
-		do
-		# ask about this 
-		# I think we want to use the below commented out version
-		# but I'm commenting it out for testing purposes
-		SpecificSeed=$(expr $j + 32000)
-		#SpecificSeed=32000
-		
-		sed -e "s/Number of neutrinos: 2000000/Number of neutrinos: ${NNT}/" -e "s/Energy exponent: 20/Energy exponent: $exp/" -e "s/Random seed: 65546/Random seed: $SpecificSeed/" ${PSIMDIR}/inputs.conf > ${PSIMDIR}/setup.conf
-		
-		#We will want to call a job here to do what this AraSim call is doing so it can run in parallel
-		cd $WorkingDir
-		output_name=/users/PAS1960/dylanwells1629/GNETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Run_Outputs/$RunName/IceMC_Outputs/${gen}_${i}_${j}.output
-		error_name=/users/PAS1960/dylanwells1629/GNETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Run_Outputs/$RunName/IceMC_Errors/${gen}_${i}_${j}.error
-		sbatch --export=ALL,gen=$gen,num=$i,WorkingDir=$WorkingDir,RunName=$RunName,Seeds=$j,PSIMDIR=$PSIMDIR --job-name=PueoCall_Array_${gen}_${i}_${j}.run --output=$output_name --error=$error_name Batch_Jobs/PueoCall_Array.sh
-		# We are going to implement a notification system
-		# This will require being able to know the job IDs
-		# We'll print this to a file and then read it in D2
-
-		cd $PSIMDIR
-		rm -f outputs/*.root
-		done
-	done
-
+	# pass
+	:
 fi
 
-
-#This submits the job for the actual PUEO antenna. Veff depends on ENergy and we need this to run once per run to compare it.
-if [ $gen -eq 10000 ]
-then
-	#sed -e "s/num_nnu/100000" /fs/ess/PAS1960/BiconeEvolutionOSC/AraSim/setup_dummy_araseed.txt > /fs/ess/PAS1960/BiconeEvolutionOSC/AraSim/setup.txt
-	sbatch --export=ALL,WorkingDir=$WorkingDir,RunName=$RunName,PSIMDIR=$PSIMDIR,NNT=$NNT Batch_Jobs/PueoActual.sh
-
-fi
-## Let's move the uan files to a directory
+# Let's move the uan files to a directory
 
 cd $WorkingDir/Run_Outputs/${RunName}/uan_files
-mkdir -m775 ${gen}_uan_files
 for i in `seq 1 $XFCOUNT`
 do
 	mkdir -m775 ${gen}_uan_files/${i}

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_D/Part_D2_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_D/Part_D2_PUEO.sh
@@ -9,7 +9,6 @@ Seeds=$5
 PSIMDIR=$6
 
 
-
 cd $WorkingDir/Run_Outputs/$RunName/PUEOFlags
 
 nFiles=0
@@ -21,21 +20,12 @@ do
 	echo "Waiting for PUEOsim jobs to finish..."
 	sleep 20
 	nFiles=$(ls -1 --file-type | grep -v '/$' | wc -l) # update nFiles
-
 done
 
 cd ..
 rm -f $WorkingDir/Run_Outputs/$RunName/PUEOFlags/*
 rm -f $WorkingDir/Run_Outputs/$RunName/PUEOConfirmed/*
-#rm -f $WorkingDir/Run_Outputs/$RunName/AraSim_Outputs/*
-#rm -f $WorkingDir/Run_Outputs/$RunName/AraSim_Errors/*
+
 wait
 
 cd $WorkingDir/Antenna_Performance_Metric
-
-if [ $gen -eq 10000 ]
-then
-	#Will need to change this
-	cp $WorkingDir/Antenna_Performance_Metric/PUEOActual/ $WorkingDir/Run_Outputs/$RunName/PUEOActual/
-fi
-

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_E/Part_E_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_E/Part_E_PUEO.sh
@@ -2,7 +2,7 @@
 ########  Fitness Score Generation (E)  ######################################################################################################### 
 #
 #
-#      1. Takes AraSim data and cocatenates each file name into one string that is then used to generate fitness scores 
+#      1. Takes the root files from the generation and runs rootAnalysis.py on them to get the fitness scores
 #
 #      2. Then gensData.py extracts useful information from generationDNA.csv and fitnessScores.csv, and writes to maxFitnessScores.csv and runData.csv
 #
@@ -24,28 +24,17 @@ IceMCExec=$9
 XFProj=${10}
 PSIMDIR=${11}
 exp=${12}
-#chmod -R 777 /fs/ess/PAS1960/BiconeEvolutionOSC/BiconeEvolution/
 
-
-#cd $WorkingDir
-# put the actual bicone results in the run name directory
-#cp ARA_Bicone_Data/AraOut_Actual_Bicone_Fixed_Polarity_2.9M_NNU.txt Run_Outputs/$RunName/AraOut_ActualBicone.txt
-
-cd $WorkingDir/Antenna_Performance_Metric/
-
-#source set_plotting_env.sh
 
 echo 'Starting fitness function calculating portion...'
-
-mv -f *.root $WorkingDir/Run_Outputs/$RunName/RootFilesGen${gen}/
-
-#python fitnessFunction_PUEO.py $NPOP $Seeds $WorkingDir/Run_Outputs/$RunName/veff_${gen} 
 
 #The rootAnalysis script only works with the base python, so unload 3.6
 module load python/3.6-conda5.2
 module unload python/3.6-conda5.2
 
 source $PSIMDIR/set_env.sh
+
+cd $WorkingDir/Antenna_Performance_Metric
 
 for i in `seq 1 $NPOP`
 do
@@ -65,41 +54,10 @@ echo "Current generation's fitness scores:" >> $WorkingDir/Generation_Data/fitne
 cat ${gen}_fitnessScores.csv >> $WorkingDir/Generation_Data/fitnessScores.csv
 cd -
 
-
-#cp fitnessScores.csv $WorkingDir/Run_Outputs/$RunName/${gen}_fitnessScores.csv
-#cp fitnessScores.csv $WorkingDir/Run_Outputs/$RunName/${gen}_vEffectives.csv
-#cp fitnessScores.csv $WorkingDir/Generation_Data/
-#cp fitnessScores.csv $WorkingDir/Run_Outputs/$RunName/Generation_Data/${gen}_fitnessScores.csv
-#cp fitnessScores.csv $WorkingDir/Run_Outputs/$RunName/Generation_Data/${gen}_vEffectives.csv
-#mv ${gen}_errorBars.csv $WorkingDir/Run_Outputs/$RunName/Generation_Data/${gen}_errorBars.csv
 cp ../Generation_Data/generationDNA.csv $WorkingDir/Run_Outputs/$RunName/Generation_Data/${gen}_generationDNA.csv
 
-
-
-#./fitnessFunction.exe $NPOP $Seeds $ScaleFactor $WorkingDir/Generation_Data/generationDNA.csv $GeoFactor $InputFiles #Here's where we add the flags for the generation
-#cp fitnessScores.csv "$WorkingDir"/Run_Outputs/$RunName/${gen}_fitnessScores.csv
-#mv fitnessScores.csv $WorkingDir/Generation_Data/
-
-#cp vEffectives.csv "$WorkingDir"/Run_Outputs/$RunName/${gen}_vEffectives.csv
-#mv vEffectives.csv $WorkingDir/Generation_Data/
-
-#cp errorBars.csv "$WorkingDir"/Run_Outputs/$RunName/${gen}_errorBars.csv
-#mv errorBars.csv $WorkingDir/Generation_Data/
-
-
-# Let's produce the plot of the gain pattern for each of the antennas
-# Start by making a directory to contain the images for the gain patterns of that generation
-### NOTE: Moved to Part F in image_maker.sh. Keep this commented for now
-#mkdir -m 775 $WorkingDir/Run_Outputs/$RunName/${gen}_Gain_Plots
-#python $WorkingDir/Antenna_Performance_Metric/polar_plotter.py $WorkingDir/Run_Outputs/$RunName/${gen}_Gain_Plots $RunName 14 $NPOP $gen
-
-cd $WorkingDir/Antenna_Performance_Metric
-
-
-source set_plotting_env.sh
-
-
 cd $WorkingDir
+source Antenna_Performance_Metric/set_plotting_env.sh
 
 if [ $gen -eq 0 ]
 then
@@ -110,19 +68,18 @@ if [ $indiv -eq $NPOP ]
 then
 	cp Generation_Data/runData.csv $WorkingDir/Run_Outputs/$RunName/Generation_Data/runData_$gen.csv
 fi
-#changing this to correct version of gensData, couldn't overwrite the current file in the Data_Generators directory. this may have caused the issue initially
-#I have updated gensData to read from the run directory, as using the GenerationData directory didn't make much sense to me.
+# changing this to correct version of gensData, couldn't overwrite the current file in the Data_Generators directory. this may have caused the issue initially
+# I have updated gensData to read from the run directory, as using the GenerationData directory didn't make much sense to me.
 python Antenna_Performance_Metric/gensDataPUEO.py $gen $WorkingDir/Run_Outputs/$RunName/Generation_Data  
-
 
 echo 'Congrats on getting a fitness score!'
 
 cd $WorkingDir
 
 mv -f Generation_Data/parents.csv Run_Outputs/$RunName/Generation_Data/${gen}_parents.csv
-mv -f Generation_Data/genes.csv Run_Outputs/$RunName/Generation_Data/${gen}_genes.csv
-mv -f Generation_Data/mutations.csv Run_Outputs/$RunName/Generationa_Data/${gen}_mutations.csv
-mv -f Generation_Data/generators.csv Run_Outputs/$RunName/Generation_Data/${gen}_generators.csv
+#mv -f Generation_Data/genes.csv Run_Outputs/$RunName/Generation_Data/${gen}_genes.csv
+#mv -f Generation_Data/mutations.csv Run_Outputs/$RunName/Generationa_Data/${gen}_mutations.csv
+#mv -f Generation_Data/generators.csv Run_Outputs/$RunName/Generation_Data/${gen}_generators.csv
 
 cd $WorkingDir/Run_Outputs/$RunName
 if [ $gen -eq 0 ]
@@ -132,4 +89,3 @@ then
 fi
 
 
-#chmod -R 777 /fs/ess/PAS1960/BiconeEvolutionOSC/BiconeEvolution/

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_E/Part_E_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_E/Part_E_PUEO.sh
@@ -38,7 +38,7 @@ cd $WorkingDir/Antenna_Performance_Metric
 
 for i in `seq 1 $NPOP`
 do
-	python rootAnalysis.py $gen $i $exp $WorkingDir/Run_Outputs/${RunName}/Generation_Data $RunName
+	python rootAnalysis.py $gen $i $exp $WorkingDir/Run_Outputs/${RunName}/Generation_Data $RunName $WorkingDir
 done
 
 module load python/3.6-conda5.2
@@ -53,6 +53,8 @@ echo "The Ohio State University GENETIS Data." > $WorkingDir/Generation_Data/fit
 echo "Current generation's fitness scores:" >> $WorkingDir/Generation_Data/fitnessScores.csv
 cat ${gen}_fitnessScores.csv >> $WorkingDir/Generation_Data/fitnessScores.csv
 cd -
+
+cp $WorkingDir/Generation_Data/fitnessScores.csv $WorkingDir/fitnessScores.csv
 
 cp ../Generation_Data/generationDNA.csv $WorkingDir/Run_Outputs/$RunName/Generation_Data/${gen}_generationDNA.csv
 

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_E/Part_E_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_E/Part_E_PUEO.sh
@@ -77,9 +77,9 @@ echo 'Congrats on getting a fitness score!'
 cd $WorkingDir
 
 mv -f Generation_Data/parents.csv Run_Outputs/$RunName/Generation_Data/${gen}_parents.csv
-#mv -f Generation_Data/genes.csv Run_Outputs/$RunName/Generation_Data/${gen}_genes.csv
-#mv -f Generation_Data/mutations.csv Run_Outputs/$RunName/Generationa_Data/${gen}_mutations.csv
-#mv -f Generation_Data/generators.csv Run_Outputs/$RunName/Generation_Data/${gen}_generators.csv
+mv -f Generation_Data/genes.csv Run_Outputs/$RunName/Generation_Data/${gen}_genes.csv 2>/dev/null
+mv -f Generation_Data/mutations.csv Run_Outputs/$RunName/Generationa_Data/${gen}_mutations.csv 2>/dev/null
+mv -f Generation_Data/generators.csv Run_Outputs/$RunName/Generation_Data/${gen}_generators.csv 2>/dev/null
 
 cd $WorkingDir/Run_Outputs/$RunName
 if [ $gen -eq 0 ]

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_F/Part_F_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_F/Part_F_PUEO.sh
@@ -12,7 +12,7 @@ Seeds=$5
 exp=$6
 GeoFactor=$7
 PSIMDIR=$8
-
+SYMMETRY=$9
 
 echo "exp: $exp"
 cd $WorkingDir
@@ -20,7 +20,7 @@ cd $WorkingDir
 cd Antenna_Performance_Metric
 
 echo 'Starting image maker portion...'
-./image_maker.sh $WorkingDir/Run_Outputs/$RunName/Generation_Data $WorkingDir/Run_Outputs/$RunName/Antenna_Images/${gen} $WorkingDir/Run_Outputs/$RunName $gen $WorkingDir $RunName $NPOP $PSIMDIR $exp
+./image_maker.sh $WorkingDir/Run_Outputs/$RunName/Generation_Data $WorkingDir/Run_Outputs/$RunName/Antenna_Images/${gen} $WorkingDir/Run_Outputs/$RunName $gen $WorkingDir $RunName $NPOP $PSIMDIR $exp $SYMMETRY
 
 source set_plotting_env.sh
 
@@ -44,15 +44,14 @@ python FScorePlotPUEO.py $WorkingDir/Run_Outputs/$RunName/Generation_Data $Worki
 #python3 color_plotsPUEO.py $WorkingDir/Run_Outputs/$RunName/Generation_Data $WorkingDir/Run_Outputs/$RunName/Generation_Data $NPOP $gen
 
 cd $WorkingDir/Run_Outputs/$RunName
-mail -s "FScore_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < FScorePlot2D.png
+#mail -s "FScore_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < FScorePlot2D.png
 #mail -s "FScore_Color_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < Fitness_Scores_RG.png
 #mail -s "Veff_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < Veff_plot.png
 #mail -s "Veff_Color_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < Veffectives_RG.png
-mail -s "Violin_Plot_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < ViolinPlot.png
+#mail -s "Violin_Plot_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < ViolinPlot.png
 mv -f *.csv Generation_Data/
 
-cd "$WorkingDir"
-#open permissions on the data files
+
 cd $WorkingDir/Run_Outputs/$RunName
 chmod -R 775 Generation_Data
 

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_F/Part_F_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_F/Part_F_PUEO.sh
@@ -4,8 +4,8 @@
 #SBATCH --time=10:00:00
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=8
-#SBATCH --output=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/Plot.output
-#SBATCH --error=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/Plot.error
+#SBATCH --output=Plot.output
+#SBATCH --error=Plot.error
 
 #variables
 #NPOP=$1

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_F/Part_F_PUEO_Job.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_F/Part_F_PUEO_Job.sh
@@ -1,18 +1,21 @@
-###########################################################################################
-#
-#    Part F: Plotting and visualizing the fitness scores
-#
-#
-##########################################################################################
-NPOP=$1
-WorkingDir=$2
-RunName=$3
-gen=$4
-Seeds=$5
-exp=$6
-GeoFactor=$7
-PSIMDIR=$8
+#!/bin/bash
+## This Job submits the plotting software for the PUEO loop
+#SBATCH --account=PAS1960
+#SBATCH --time=10:00:00
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=8
+#SBATCH --output=Plot.output
+#SBATCH --error=Plot.error
 
+#variables
+#NPOP=$1
+#WorkingDir=$2
+#RunName=$3
+#gen=$4
+#Seeds=$5
+#exp=$6
+#GeoFactor=$7
+#PSIMDIR=$8
 
 echo "exp: $exp"
 cd $WorkingDir

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_F/Part_F_PUEO_Job.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_F/Part_F_PUEO_Job.sh
@@ -16,6 +16,7 @@
 #exp=$6
 #GeoFactor=$7
 #PSIMDIR=$8
+#SYMMETRY=$9
 
 echo "exp: $exp"
 cd $WorkingDir
@@ -23,7 +24,7 @@ cd $WorkingDir
 cd Antenna_Performance_Metric
 
 echo 'Starting image maker portion...'
-./image_maker.sh $WorkingDir/Run_Outputs/$RunName/Generation_Data $WorkingDir/Run_Outputs/$RunName/Antenna_Images/${gen} $WorkingDir/Run_Outputs/$RunName $gen $WorkingDir $RunName $NPOP $PSIMDIR $exp
+./image_maker.sh $WorkingDir/Run_Outputs/$RunName/Generation_Data $WorkingDir/Run_Outputs/$RunName/Antenna_Images/${gen} $WorkingDir/Run_Outputs/$RunName $gen $WorkingDir $RunName $NPOP $PSIMDIR $exp $SYMMETRY
 
 source set_plotting_env.sh
 
@@ -47,14 +48,13 @@ python FScorePlotPUEO.py $WorkingDir/Run_Outputs/$RunName/Generation_Data $Worki
 #python3 color_plotsPUEO.py $WorkingDir/Run_Outputs/$RunName/Generation_Data $WorkingDir/Run_Outputs/$RunName/Generation_Data $NPOP $gen
 
 cd $WorkingDir/Run_Outputs/$RunName
-mail -s "FScore_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < FScorePlot2D.png
+#mail -s "FScore_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < FScorePlot2D.png
 #mail -s "FScore_Color_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < Fitness_Scores_RG.png
 #mail -s "Veff_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < Veff_plot.png
 #mail -s "Veff_Color_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < Veffectives_RG.png
-mail -s "Violin_Plot_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < ViolinPlot.png
+#mail -s "Violin_Plot_${RunName}_Gen_${gen}" dropbox.2dwp1o@zapiermail.com < ViolinPlot.png
 mv -f *.csv Generation_Data/
 
-cd "$WorkingDir"
 #open permissions on the data files
 cd $WorkingDir/Run_Outputs/$RunName
 chmod -R 775 Generation_Data

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
@@ -19,12 +19,12 @@
 module load python/3.6-conda5.2
 
 ####### VARIABLES: LINES TO CHECK OVER WHEN STARTING A NEW RUN ###############################################################################################
-RunName='2023_07_20_test6'	## This is the name of the run. You need to make a unique name each time you run.
+RunName='2023_07_22_test2'	## This is the name of the run. You need to make a unique name each time you run.
 TotalGens=100			## number of generations (after initial) to run through
 NPOP=5			## number of individuals per generation; please keep this value below 99
 Seeds=1			## This is how many AraSim jobs will run for each individual## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
 FREQ=60				## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
-NNT=40000			## Number of Neutrinos Thrown in AraSim   
+NNT=1000			## Number of Neutrinos Thrown in AraSim   
 exp=19				## exponent of the energy for the neutrinos in AraSim
 ScaleFactor=1.0			## ScaleFactor used when punishing fitness scores of antennae larger than the drilling holes
 GeoFactor=1			## This is the number by which we are scaling DOWN our antennas. This is passed to many files
@@ -88,6 +88,7 @@ echo $XFProj
 AraSimExec="${WorkingDir}/../../../../AraSim"
 #$BEOSC/AraSim ## Location of AraSim directory
 PSIMDIR="/fs/ess/PAS1960/buildingPueoSim" 
+#PSIMDIR="/users/PAS1960/dylanwells1629/buildingPueoSim"
 ##Source araenv.sh for AraSim libraries##
 #source /fs/ess/PAS1960/BiconeEvolutionOSC/araenv.sh
 if [ $PUEO -eq 1 ]
@@ -400,9 +401,9 @@ do
 		else
 			if [ $JobPlotting -eq 0 ]
 			then
-				./Loop_Parts/Part_F/Part_F_PUEO.sh $NPOP $WorkingDir $RunName $gen $Seeds $exp $ScaleFactor $PSIMDIR
+				./Loop_Parts/Part_F/Part_F_PUEO.sh $NPOP $WorkingDir $RunName $gen $Seeds $exp $ScaleFactor $PSIMDIR $SYMMETRY
 			else
-				sbatch --export=ALL,NPOP=$NPOP,WorkingDir=$WorkingDir,RunName=$RunName,gen=$gen,Seeds=$Seeds,exp=$exp,GeoFactor=$ScaleFactor,PSIMDIR=$PSIMDIR --job-name=Plotting_${RunName}_${gen}  ./Loop_Parts/Part_F/Part_F_PUEO.sh
+				sbatch --export=ALL,NPOP=$NPOP,WorkingDir=$WorkingDir,RunName=$RunName,gen=$gen,Seeds=$Seeds,exp=$exp,GeoFactor=$ScaleFactor,PSIMDIR=$PSIMDIR,SYMMETRY=$SYMMETRY --job-name=Plotting_${RunName}_${gen}  ./Loop_Parts/Part_F/Part_F_PUEO.sh
 			fi
 		fi
 		state=1

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
@@ -45,18 +45,34 @@ DEBUG_MODE=0			## 1 for testing (ex: send specific seeds), 0 for real runs
 				## These next variables are the values passed to the GA
 REPRODUCTION=5			## Number (not fraction!) of individuals formed through reproduction
 CROSSOVER=0 #84			## Number (not fraction!) of individuals formed through crossover
-MUTATION=0 #16 #1			## Probability of mutation (divided by 100)
+MUTATION=0 #16 #1		## Number (not fraction!) of individuals formed through crossover	
 SIGMA=0 #5				## Standard deviation for the mutation operation (divided by 100)
-ROULETTE=5 #20			## Percent of individuals selected through roulette (divided by 10)
-TOURNAMENT=0 #20			## Percent of individuals selected through tournament (divided by 10)
-RANK=0 #60				## Percent of individuals selected through rank (divided by 10)
+ROULETTE=5 #20			## Number (not fraction!) of individuals formed through crossover
+TOURNAMENT=0 #20		## Number (not fraction!) of individuals formed through crossover
+RANK=0 #60				## Number (not fraction!) of individuals formed through crossover
 ELITE=0				## Elite function on/off (1/0)
 
 #####################################################################################################################################################
 
+######## Check For Errors in Variables ################################################################################################################
+
+
+if [ $((REPRODUCTION + CROSSOVER + MUTATION)) -gt $NPOP ]
+then
+	echo "ERROR: reproduction + crossover + mutation must be less than or equal to NPOP"
+	exit 1
+fi
+
+if [ $((ROULETTE + TOURNAMENT + RANK)) -gt $NPOP ]
+then
+	echo "ERROR: roulette + tournament + rank must be less than or equal to NPOP"
+	exit 1
+fi
+
+
 
 ########  INITIALIZATION OF DIRECTORIES  ###############################################################################################################
-BEOSC=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/
+BEOSC=/users/PAS1960/dylanwells1629/developing/GENETIS_PUEO/
 WorkingDir=`pwd` ## this is where the loop is; on OSC this is /fs/ess/PAS1960/BiconeEvolutionOSC/BiconeEvolution/current_antenna_evo_build_XF_Loop/Evolutionary_Loop
 echo $WorkingDir
 XmacrosDir=$WorkingDir/../Xmacros 

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
@@ -19,12 +19,12 @@
 module load python/3.6-conda5.2
 
 ####### VARIABLES: LINES TO CHECK OVER WHEN STARTING A NEW RUN ###############################################################################################
-RunName='2023_06_21_Test_11'	## This is the name of the run. You need to make a unique name each time you run.
+RunName='2023_07_19_test14'	## This is the name of the run. You need to make a unique name each time you run.
 TotalGens=100			## number of generations (after initial) to run through
 NPOP=5			## number of individuals per generation; please keep this value below 99
-Seeds=1			## This is how many AraSim jobs will run for each individual## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
+Seeds=10			## This is how many AraSim jobs will run for each individual## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
 FREQ=60				## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
-NNT=400			## Number of Neutrinos Thrown in AraSim   
+NNT=40000			## Number of Neutrinos Thrown in AraSim   
 exp=19				## exponent of the energy for the neutrinos in AraSim
 ScaleFactor=1.0			## ScaleFactor used when punishing fitness scores of antennae larger than the drilling holes
 GeoFactor=1			## This is the number by which we are scaling DOWN our antennas. This is passed to many files
@@ -79,7 +79,7 @@ echo $XFProj
 #AraSimExec="/fs/ess/PAS1960/BiconeEvolutionOSC/AraSim"  ##Location of AraSim.exe
 AraSimExec="${WorkingDir}/../../../../AraSim"
 #$BEOSC/AraSim ## Location of AraSim directory
-PSIMDIR="/fs/ess/PAS1960/buildingPueoSim/" 
+PSIMDIR="/fs/ess/PAS1960/buildingPueoSim" 
 ##Source araenv.sh for AraSim libraries##
 #source /fs/ess/PAS1960/BiconeEvolutionOSC/araenv.sh
 if [ $PUEO -eq 1 ]
@@ -168,7 +168,8 @@ echo "${indiv}"
 #InitialGen=${gen}
 
 for gen in `seq $InitialGen $TotalGens`
-do
+do	
+	genstart=`date +%s`
 	#read -p "Starting generation ${gen} at location ${state}. Press any key to continue... " -n1 -s
 	
 
@@ -190,6 +191,7 @@ do
 		mkdir -m777 $WorkingDir/Run_Outputs/$RunName/PUEOFlags
 		mkdir -m775 $WorkingDir/Run_Outputs/$RunName/Root_Files
 		mkdir -m775 $PSIMDIR/outputs/${RunName}
+		touch $WorkingDir/Run_Outputs/$RunName/time.txt
 
 		head -n 53 Loop_Scripts/Asym_XF_Loop.sh | tail -n 33 > $WorkingDir/Run_Outputs/$RunName/run_details.txt
 		# Create the run's date and save it in the run's directory
@@ -203,6 +205,8 @@ do
 	##Here, we are running the genetic algorithm and moving the outputs to csv files 
 	if [ $state -eq 1 ]
 	then
+		echo "Times for generation ${gen}" >> $WorkingDir/Run_Outputs/$RunName/time.txt
+		start=`date +%s`
 		if [ $PUEO -eq 0 ]
 		then
 			if [ $CURVED -eq 0 ] #Evolve straight sides
@@ -216,13 +220,16 @@ do
 		fi
 		state=2
 		./SaveState_Prototype.sh $gen $state $RunName $indiv
-
+		end=`date +%s`
+		runtime=$((end-start))
+		echo "Part A took ${runtime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 	fi
 
 
 	## Part B1 ##
 	if [ $state -eq 2 ]
 	then
+		start=`date +%s`
 		if [ $PUEO -eq 1 ]
 		then
 			./Loop_Parts/Part_B/Part_B_PUEO.sh $indiv $gen $NPOP $WorkingDir $RunName $XmacrosDir $XFProj $GeoFactor $num_keys $SYMMETRY $XFCOUNT
@@ -256,12 +263,16 @@ do
 		fi
 		state=3
 		./SaveState_Prototype.sh $gen $state $RunName $indiv
+		end=`date +%s`
+		runtime=$((end-start))
+		echo "Part B1 took ${runtime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 	fi
 		
 
 	## Part B2 ##
 	if [ $state -eq 3 ]
 	then
+		start=`date +%s`
 		if [ $PUEO -eq 1 ]
 		then
 			./Loop_Parts/Part_B/Part_B_job2_PUEO.sh $indiv $gen $NPOP $WorkingDir $RunName $XmacrosDir $XFProj $GeoFactor $num_keys $NSECTIONS $XFCOUNT
@@ -277,11 +288,15 @@ do
 		state=4
 
 		./SaveState_Prototype.sh $gen $state $RunName $indiv
+		end=`date +%s`
+		runtime=$((end-start))
+		echo "Part B2 took ${runtime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 	fi
 
 	## Part C ##
 	if [ $state -eq 4 ]
 	then
+	  start=`date +%s`
 	  indiv=1
 	  if [ $PUEO -eq 1 ]
 	  then
@@ -291,12 +306,15 @@ do
 	  fi
 		state=5
 		./SaveState_Prototype.sh $gen $state $RunName $indiv
-
+	  end=`date +%s`
+	  runtime=$((end-start))
+	  echo "Part C took ${runtime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 	fi
 
 	## Part D1 ##
 	if [ $state -eq 5 ]
 	then
+		start=`date +%s`
 	        #The reason here why Part_D1.sh is run after the save state is changed is because all Part_D1 does is submit AraSim jobs which are their own jobs and run on their own time
 		#We need to make a new AraSim job script which takes the runname as a flag 
 		#./Loop_Parts/Part_D/Part_D1_AraSeed.sh $gen $NPOP $WorkingDir $AraSimExec $exp $NNT $RunName $Seeds $DEBUG_MODE
@@ -310,12 +328,15 @@ do
 		state=6
 
 		./SaveState_Prototype.sh $gen $state $RunName $indiv
-
+		end=`date +%s`
+		runtime=$((end-start))
+		echo "Part D1 took ${runtime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 	fi
 
 	## Part D2 ##
 	if [ $state -eq 6 ]
 	then
+		start=`date +%s`
 		#./Part_D2_AraSeed.sh 
 		if [ $PUEO -eq 0 ]
 		then
@@ -326,7 +347,9 @@ do
 		fi
 		state=7
 		./SaveState_Prototype.sh $gen $state $RunName $indiv
-
+		end=`date +%s`
+		runtime=$((end-start))
+		echo "Part D2 took ${runtime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 	fi
 
 	## Part E ##
@@ -335,6 +358,7 @@ do
 	## moves the .uan files from Antenna Performance Metric to RunOutputs/$RunName folder
 	if [ $state -eq 7 ]
 	then
+		start=`date +%s`
 		if [ $PUEO -eq 0 ]
 		then
 			if [ $CURVED -eq 0 ]	# Evolve straight sides
@@ -348,12 +372,15 @@ do
 		fi
 		state=8
 		./SaveState_Prototype.sh $gen $state $RunName $indiv 
-
+		end=`date +%s`
+		runtime=$((end-start))
+		echo "Part E took ${runtime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 	fi
 
 	## Part F ##
 	if [ $state -eq 8 ]
 	then
+		start=`date +%s`
 		if [ $PUEO -eq 0 ]
 		then
 			if [ $CURVED -eq 0 ]
@@ -367,7 +394,13 @@ do
 		fi
 		state=1
 		./SaveState_Prototype.sh $gen $state $RunName $indiv
+		end=`date +%s`
+		runtime=$((end-start))
+		echo "Part F took ${runtime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 	fi
+	genend=`date +%s`
+	genruntime=$((genend-genstart))
+	echo "Generation ${gen} took ${genruntime} seconds" >> $WorkingDir/Run_Outputs/$RunName/time.txt
 done
 
 cp generationDNA.csv "$WorkingDir"/Run_Outputs/$RunName/FinalGenerationParameters.csv

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
@@ -70,7 +70,7 @@ PSIMDIR="/fs/ess/PAS1960/buildingPueoSim/"
 #source /fs/ess/PAS1960/BiconeEvolutionOSC/araenv.sh
 if [ $PUEO -eq 1 ]
 then
-	source /fs/ess/PAS1960/buildingPueoSim/set_env.sh	
+	source ${PSIMDIR}/set_env.sh	
 	if [ $SYMMETRY -eq 0 ]
 	then
 		XFCOUNT=$((NPOP*2))
@@ -175,6 +175,7 @@ do
 		mkdir -m777 $WorkingDir/Run_Outputs/$RunName/Generation_Data
 		mkdir -m777 $WorkingDir/Run_Outputs/$RunName/PUEOFlags
 		mkdir -m775 $WorkingDir/Run_Outputs/$RunName/Root_Files
+		mkdir -m775 $PSIMDIR/outputs/${RunName}
 
 		head -n 53 Loop_Scripts/Asym_XF_Loop.sh | tail -n 33 > $WorkingDir/Run_Outputs/$RunName/run_details.txt
 		# Create the run's date and save it in the run's directory

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
@@ -19,10 +19,10 @@
 module load python/3.6-conda5.2
 
 ####### VARIABLES: LINES TO CHECK OVER WHEN STARTING A NEW RUN ###############################################################################################
-RunName='2023_07_20_test4'	## This is the name of the run. You need to make a unique name each time you run.
+RunName='2023_07_20_test6'	## This is the name of the run. You need to make a unique name each time you run.
 TotalGens=100			## number of generations (after initial) to run through
-NPOP=50			## number of individuals per generation; please keep this value below 99
-Seeds=5			## This is how many AraSim jobs will run for each individual## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
+NPOP=5			## number of individuals per generation; please keep this value below 99
+Seeds=1			## This is how many AraSim jobs will run for each individual## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
 FREQ=60				## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
 NNT=40000			## Number of Neutrinos Thrown in AraSim   
 exp=19				## exponent of the energy for the neutrinos in AraSim
@@ -43,15 +43,16 @@ SEPARATION=0    		## If 1, separation evolves. If 0, separation is constant
 NSECTIONS=2 			## The number of chromosomes
 DEBUG_MODE=0			## 1 for testing (ex: send specific seeds), 0 for real runs
 				## These next variables are the values passed to the GA
-REPRODUCTION=2			## Number (not fraction!) of individuals formed through reproduction
-CROSSOVER=44 #84			## Number (not fraction!) of individuals formed through crossover
-MUTATION=2 #16 #1		## Number (not fraction!) of individuals formed through crossover	
+REPRODUCTION=1			## Number (not fraction!) of individuals formed through reproduction
+CROSSOVER=2 #84			## Number (not fraction!) of individuals formed through crossover
+MUTATION=1 #16 #1		## Number (not fraction!) of individuals formed through crossover	
 SIGMA=5 #5				## Standard deviation for the mutation operation (divided by 100)
-ROULETTE=10 #20			## Number (not fraction!) of individuals formed through crossover
-TOURNAMENT=10 #20		## Number (not fraction!) of individuals formed through crossover
-RANK=30 #60				## Number (not fraction!) of individuals formed through crossover
+ROULETTE=1 #20			## Number (not fraction!) of individuals formed through crossover
+TOURNAMENT=1 #20		## Number (not fraction!) of individuals formed through crossover
+RANK=3 #60				## Number (not fraction!) of individuals formed through crossover
 ELITE=0				## Elite function on/off (1/0)
 
+JobPlotting=0        ## 1 to submit a job to plot the fitness scores, 0 to not submit a job to plot the fitness scores
 #####################################################################################################################################################
 
 ######## Check For Errors in Variables ################################################################################################################
@@ -76,7 +77,8 @@ then
 fi
 
 ########  INITIALIZATION OF DIRECTORIES  ###############################################################################################################
-BEOSC=/users/PAS1960/dylanwells1629/developing/GENETIS_PUEO/
+#BEOSC=/users/PAS1960/dylanwells1629/developing/GENETIS_PUEO/
+BEOSC=/fs/ess/PAS1960/HornEvolutionOSC/GENETIS_PUEO/
 WorkingDir=`pwd` ## this is where the loop is; on OSC this is /fs/ess/PAS1960/BiconeEvolutionOSC/BiconeEvolution/current_antenna_evo_build_XF_Loop/Evolutionary_Loop
 echo $WorkingDir
 XmacrosDir=$WorkingDir/../Xmacros 
@@ -396,7 +398,12 @@ do
 				./Loop_Parts/Part_F/Part_F_Curved.sh $NPOP $WorkingDir $RunName $gen $Seeds $NSECTIONS
 			fi
 		else
-			sbatch --export=ALL,gen=$gen,NPOP=$NPOP,WorkingDir=$WorkingDir,RunName=$RunName,gen=$gen,Seeds=$Seeds,exp=$exp,GeoFactor=$ScaleFactor,PSIMDIR=$PSIMDIR --job-name=Plotting_${RunName}_${gen}  ./Loop_Parts/Part_F/Part_F_PUEO.sh
+			if [ $JobPlotting -eq 0 ]
+			then
+				./Loop_Parts/Part_F/Part_F_PUEO.sh $NPOP $WorkingDir $RunName $gen $Seeds $exp $ScaleFactor $PSIMDIR
+			else
+				sbatch --export=ALL,NPOP=$NPOP,WorkingDir=$WorkingDir,RunName=$RunName,gen=$gen,Seeds=$Seeds,exp=$exp,GeoFactor=$ScaleFactor,PSIMDIR=$PSIMDIR --job-name=Plotting_${RunName}_${gen}  ./Loop_Parts/Part_F/Part_F_PUEO.sh
+			fi
 		fi
 		state=1
 		./SaveState_Prototype.sh $gen $state $RunName $indiv

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
@@ -19,10 +19,10 @@
 module load python/3.6-conda5.2
 
 ####### VARIABLES: LINES TO CHECK OVER WHEN STARTING A NEW RUN ###############################################################################################
-RunName='2023_07_19_test14'	## This is the name of the run. You need to make a unique name each time you run.
+RunName='2023_07_20_test4'	## This is the name of the run. You need to make a unique name each time you run.
 TotalGens=100			## number of generations (after initial) to run through
-NPOP=5			## number of individuals per generation; please keep this value below 99
-Seeds=10			## This is how many AraSim jobs will run for each individual## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
+NPOP=50			## number of individuals per generation; please keep this value below 99
+Seeds=5			## This is how many AraSim jobs will run for each individual## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
 FREQ=60				## the number frequencies being iterated over in XF (Currectly only affects the output.xmacro loop)
 NNT=40000			## Number of Neutrinos Thrown in AraSim   
 exp=19				## exponent of the energy for the neutrinos in AraSim
@@ -43,13 +43,13 @@ SEPARATION=0    		## If 1, separation evolves. If 0, separation is constant
 NSECTIONS=2 			## The number of chromosomes
 DEBUG_MODE=0			## 1 for testing (ex: send specific seeds), 0 for real runs
 				## These next variables are the values passed to the GA
-REPRODUCTION=5			## Number (not fraction!) of individuals formed through reproduction
-CROSSOVER=0 #84			## Number (not fraction!) of individuals formed through crossover
-MUTATION=0 #16 #1		## Number (not fraction!) of individuals formed through crossover	
-SIGMA=0 #5				## Standard deviation for the mutation operation (divided by 100)
-ROULETTE=5 #20			## Number (not fraction!) of individuals formed through crossover
-TOURNAMENT=0 #20		## Number (not fraction!) of individuals formed through crossover
-RANK=0 #60				## Number (not fraction!) of individuals formed through crossover
+REPRODUCTION=2			## Number (not fraction!) of individuals formed through reproduction
+CROSSOVER=44 #84			## Number (not fraction!) of individuals formed through crossover
+MUTATION=2 #16 #1		## Number (not fraction!) of individuals formed through crossover	
+SIGMA=5 #5				## Standard deviation for the mutation operation (divided by 100)
+ROULETTE=10 #20			## Number (not fraction!) of individuals formed through crossover
+TOURNAMENT=10 #20		## Number (not fraction!) of individuals formed through crossover
+RANK=30 #60				## Number (not fraction!) of individuals formed through crossover
 ELITE=0				## Elite function on/off (1/0)
 
 #####################################################################################################################################################

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
@@ -69,8 +69,6 @@ then
 	exit 1
 fi
 
-
-
 ########  INITIALIZATION OF DIRECTORIES  ###############################################################################################################
 BEOSC=/users/PAS1960/dylanwells1629/developing/GENETIS_PUEO/
 WorkingDir=`pwd` ## this is where the loop is; on OSC this is /fs/ess/PAS1960/BiconeEvolutionOSC/BiconeEvolution/current_antenna_evo_build_XF_Loop/Evolutionary_Loop
@@ -287,7 +285,7 @@ do
 	  indiv=1
 	  if [ $PUEO -eq 1 ]
 	  then
-			./Loop_Parts/Part_C/Part_C_PUEO.sh $NPOP $WorkingDir $RunName $gen $indiv $SYMMETRY
+			./Loop_Parts/Part_C/Part_C_PUEO.sh $NPOP $WorkingDir $RunName $gen $indiv $SYMMETRY $PSIMDIR
 	  else
 			./Loop_Parts/Part_C/Part_C.sh $NPOP $WorkingDir $RunName $gen $indiv
 	  fi

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Scripts/Asym_XF_Loop.sh
@@ -69,6 +69,12 @@ then
 	exit 1
 fi
 
+if [ $((CROSSOVER % 2)) -ne 0 ]
+then
+	echo "ERROR: crossover must be even"
+	exit 1
+fi
+
 ########  INITIALIZATION OF DIRECTORIES  ###############################################################################################################
 BEOSC=/users/PAS1960/dylanwells1629/developing/GENETIS_PUEO/
 WorkingDir=`pwd` ## this is where the loop is; on OSC this is /fs/ess/PAS1960/BiconeEvolutionOSC/BiconeEvolution/current_antenna_evo_build_XF_Loop/Evolutionary_Loop


### PR DESCRIPTION
This pull request will:
1. Run 40 processes of pueoSim in parallel per job submitted
2. Add a timer file to keep track of how long each section of the loop takes
3. Add a catch in the main bash script for incorrect GA variables
4. Clean up print statements and unnecessary commands/comments (Ex: comments for iceMC)
5. Add a switch for job plotting
6. Un-hardcode paths to allow for testing outside of /fs/ess/PAS1960
7. fix a lot of bugs

I've run a few test runs of this branch on my user, and it has completed the first generation without errors, saving all the plots and antenna images.
However, there seems to be a remaining issue with XF that causes some antenna simulations to terminate with the message: "Unstable calculation detected. Terminating XFSolver."

