### PR TITLE
semi-dynamically allocate number of psim jobs

### DIFF
--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/calculating_NNT.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/calculating_NNT.py
@@ -1,6 +1,6 @@
 import argparse
 
-def parseArgs():
+def parse_args():
     '''Parse the command line arguments'''
     parser = argparse.ArgumentParser()
     parser.add_argument('jobs_running', type=int, 

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/calculating_NNT.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/calculating_NNT.py
@@ -35,6 +35,6 @@ def main(args):
 
     
 if __name__ == '__main__':
-    args = parseArgs()
+    args = parse_args()
     main(args)
     

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/calculating_NNT.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/calculating_NNT.py
@@ -1,0 +1,40 @@
+import argparse
+
+def parseArgs():
+    '''Parse the command line arguments'''
+    parser = argparse.ArgumentParser()
+    parser.add_argument('jobs_running', type=int, 
+                        help='count of all jobs currently running')
+    parser.add_argument('gpu_jobs_left', type=int, 
+                        help='number of GPU jobs left')
+    parser.add_argument('xfkeys', type=int, 
+                        help='number of XF keys used in the run')
+    parser.add_argument('nnt', type=int, 
+                        help='Total number of neutrinos per antenna')
+    parser.add_argument('max_jobs', type=int, 
+                        help='Maximum number of concurrent jobs')
+    args = parser.parse_args()
+    return args
+
+
+def main(args):
+    '''Calculate the number of neutrinos per job and the number of jobs'''
+    if args.gpu_jobs_left > args.xfkeys:
+        num_jobs = int((args.max_jobs - args.xfkeys) / args.xfkeys)
+    else:
+        # If we're able to run more jobs for the last set of simulations,
+        # we want to run as many as possible
+        case1 = (args.max_jobs - args.jobs_running) / args.gpu_jobs_left
+        case2 = (args.max_jobs - args.xfkeys) / args.xfkeys
+        
+        num_jobs = int(max(case1, case2))
+    nnt_per_job = int(args.nnt / num_jobs / 40)
+    
+    # The bash script will parse the print statement into a variable
+    print(f"{nnt_per_job},{num_jobs}")
+
+    
+if __name__ == '__main__':
+    args = parseArgs()
+    main(args)
+    

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/calculating_NNT.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/calculating_NNT.py
@@ -37,4 +37,3 @@ def main(args):
 if __name__ == '__main__':
     args = parse_args()
     main(args)
-    

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/GPU_XF_Job_Parallel.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/GPU_XF_Job_Parallel.sh
@@ -38,7 +38,7 @@ symmetry_multiplier=1
 if [ $SYMMETRY -eq 1 ]
 then
 	symmetry_multiplier=2
-else
+fi
 
 indiv_in_pop=$SLURM_ARRAY_TASK_ID
 
@@ -52,7 +52,8 @@ else
 fi
 
 while [ $indiv_in_pop -le $upper_limit ]
-	individual_number=$((${gen}*${NPOP}*${symmetry_multiplier}+${indiv_in_pop}))
+do
+	individual_number=$((gen*NPOP*symmetry_multiplier+indiv_in_pop))
 
 	## Based on the individual number, we need the right parent directory
 	## This involves checking the individual number being submitted
@@ -89,11 +90,11 @@ while [ $indiv_in_pop -le $upper_limit ]
 	echo "The GPU job is done!" >> $flag_file
 
 	# iterate which individual we're on
-	indiv_in_pop=$(($indiv_in_pop+${batch_size}*${symmetry_multiplier}))
+	indiv_in_pop=$((indiv_in_pop+batch_size*symmetry_multiplier))
 
 	# if we go over tartget, the job doesn't need to wait for
 	# output xmacro and can terminate
-	if [ $indiv_in_pop -gt $target ]
+	if [ $indiv_in_pop -gt $upper_limit ]
 	then
 		exit 0
 	fi

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array_Indiv.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array_Indiv.sh
@@ -54,7 +54,7 @@ echo "PSIMS finished"
 mkdir -p -m775 $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/$num
 mkdir -p -m775 $WorkingDir/Run_Outputs/$RunName/PUEOFlags/$num
 # move the root files
-for ((i=$run_num; i<$((threads + run_num)); i++))
+for ((i=run_num; i<$((threads + run_num)); i++))
 do
     mv $TMPDIR/run${i}/IceFinal_${i}_skimmed.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/$num/IceFinal_skimmed_${gen}_${num}_${i}.root
     #mv $TMPDIR/run${i}/IceFinal_${i}_allTree.root $WorkingDir/Run_Outputs/$RunName/Root_Files/${gen}_Root_Files/$num/IceFinal_allTree_${gen}_${num}_${i}.root
@@ -65,7 +65,7 @@ done
 
 echo $gen > $TMPDIR/${run_num}.txt
 echo $num >> $TMPDIR/${run_num}.txt
-echo $seed >> $TMPDIR/${run_numd}.txt
+echo $seed >> $TMPDIR/${run_num}.txt
 
 # move the flag file
 mv $TMPDIR/${run_num}.txt $WorkingDir/Run_Outputs/$RunName/PUEOFlags/$num
@@ -77,7 +77,7 @@ rm ${run_num}.txt.*
 
 #if there are 49 flags in the PUEOFlags/$num directory, run the root analysis
 flag_count=$(ls | wc -l)
-if [ $flag_count -eq 49 ]
+if [ $flag_count -eq $num_jobs ]
 then
     module load python/3.6-conda5.2
     module unload python/3.6-conda5.2

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/single_XF_output_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/single_XF_output_PUEO.sh
@@ -32,7 +32,7 @@ cd $WorkingDir/Antenna_Performance_Metric
 #echo "files in Antenna_Performance_Metric:"
 #ls
 
-for freq in `seq 1 131`
+for freq in $(seq 1 131)
 do
 	mv ${individual_number}_${freq}.uan $WorkingDir/Run_Outputs/$RunName/${gen}_${individual_number}_${freq}.uan
 done
@@ -41,7 +41,7 @@ done
 module load python/3.6-conda5.2
 python XFintoPUEO_Symmetric.py $NPOP $WorkingDir $RunName $gen $WorkingDir/Test_Outputs --single=$individual_number
 
-chmod 777 * $WorkingDir/Test_Outputs/*
+chmod 777 $WorkingDir/Test_Outputs/*
 
 mkdir -p -m775 $WorkingDir/Run_Outputs/$RunName/uan_files/${gen}_uan_files/$individual_number
 cp $WorkingDir/Run_Outputs/$RunName/${gen}_${individual_number}_*.uan $WorkingDir/Run_Outputs/$RunName/uan_files/${gen}_uan_files/$individual_number

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B_PUEO.sh
@@ -43,7 +43,7 @@ fi
 # the directories are the simulation directories from gen*NPOP+1 to gen*NPOP+10
 # Note that for PUEO, we need TWO XF simulation per individual
 # This is because we need to do the VPol and Hpol
-for i in `seq 1 $XFCOUNT`
+for i in $(seq 1 $XFCOUNT)
 do
         # first, declare the number of the individual we are checking
 	individual_number=$(($gen*$XFCOUNT + $i))
@@ -223,10 +223,6 @@ job_file=$WorkingDir/Batch_Jobs/GPU_XF_Job.sh
 if [ $ParallelXFPUEO -eq 1 ]
 then
 	job_file=$WorkingDir/Batch_Jobs/GPU_XF_Job_Parallel.sh
-fi
-
-if [ $ParallelXFPUEO -eq 1 ]
-then
 	cd $WorkingDir/Run_Outputs/$RunName
 	rm GPUFlags/* 2> /dev/null
 	# remove pueo flags recursively
@@ -248,4 +244,4 @@ else
 fi
 
 echo "Submitting XF jobs with batch size $batch_size"
-sbatch --array=1-${XFCOUNT}%${batch_size} --export=ALL,WorkingDir=$WorkingDir,RunName=$RunName,XmacrosDir=$XmacrosDir,XFProj=$XFProj,NPOP=$NPOP,indiv=$individual_number,indiv_dir=$indiv_dir,gen=${gen},SYMMETRY=$SYMMETRY,PSIMDIR=$PSIMDIR,batch_size=$batch_size,SingleBatch=$SingleBatch --job-name=${RunName} --time=${job_time} $job_file 
+sbatch --array=1-${XFCOUNT}%${batch_size} --export=ALL,WorkingDir=$WorkingDir,RunName=$RunName,XmacrosDir=$XmacrosDir,XFProj=$XFProj,NPOP=$NPOP,indiv=$individual_number,gen=${gen},SYMMETRY=$SYMMETRY,PSIMDIR=$PSIMDIR,batch_size=$batch_size,SingleBatch=$SingleBatch --job-name=${RunName} --time=${job_time} $job_file 


### PR DESCRIPTION
Previously, the number of pueoSim jobs submitted was hard-coded to 49 to allow for 5 sets of them (5=XFKeys) to be run at once. Since we now have more keys, we want the loop to be able to figure out how many jobs to submit based on the current environment. 

I created the python script calculating_NNT.py to calculate this number for the bash script. Also, if there are additional free jobs for the last few antennas run through XF, they will submit more jobs with fewer neutrinos each to reduce the amount of time waiting without running XF.