### PR TITLE
bugfix pueo loop

### DIFF
--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/XFintoPUEO_Symmetric.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/XFintoPUEO_Symmetric.py
@@ -76,9 +76,9 @@ def callFunctions(indiv):
                freq_list, file_header / f'vv_0_{g.gen}_{indiv}')
     writeGains(vpol_gain_t[0], vpol_phase_t[0],
                freq_list, file_header / f'hh_0_{g.gen}_{indiv}')
-    writeGains(hpol_data_t[0], hpol_phase_t[0],
+    writeGains(hpol_gain_t[0], hpol_phase_t[0],
                freq_list, file_header / f'vh_0_{g.gen}_{indiv}')
-    writeGains(hpol_data_t[0], hpol_phase_t[0],
+    writeGains(hpol_gain_t[0], hpol_phase_t[0],
                freq_list, file_header / f'hv_0_{g.gen}_{indiv}')
     ## Now we need to be more careful for the az and el files
     ## We want the angles 5, 10, 20, 30, 45, 90

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/fitFix.py
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Antenna_Performance_Metric/fitFix.py
@@ -15,7 +15,7 @@ error_plusses = np.zeros(g.npop)
 error_minuses = np.zeros(g.npop)
 for i in range(g.npop):
     #get the single line of the csv file as a float
-    df = pd.read_csv(g.source / str(i+1) / f'{g.gen}_pueoOut.csv', header=None)
+    df = pd.read_csv(g.source / str(i) / f'{g.gen}_pueoOut.csv', header=None)
     #fitness is in the first row second column
     fitness = df.iloc[0,1]
     error_plus = df.iloc[0,2]

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array_Indiv.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/PueoCall_Array_Indiv.sh
@@ -3,7 +3,7 @@
 ## Here's the command:
 ## sbatch --array=1-NPOP*SEEDS%max --export=ALL,(variables) PueoCall_Array.sh
 #SBATCH -A PAS1960
-#SBATCH -t 00:30:00
+#SBATCH -t 01:00:00
 #SBATCH -N 1
 #SBATCH -n 40
 #SBATCH --output=Run_Outputs/%x/PUEO_Outputs/PUEOsim_%a.output
@@ -18,6 +18,10 @@
 #NPOP=$6
 #NNT=$7
 #Exp=$8
+
+echo $num_jobs
+echo $indiv
+
 
 threads=40
 
@@ -43,6 +47,7 @@ echo "Running PSIM"
 for ((i=$run_num; i<$((threads + run_num)); i++))
 do
     # Run 40 processes of pueoSim 
+    echo "starting pueoSim ${i}"
     touch pueoout${i}.txt
     ./simulatePueo -i pueo.conf -o $TMPDIR -r $i -n $NNT -e $Exp > pueoout${i}.txt &
 done
@@ -77,6 +82,8 @@ rm ${run_num}.txt.*
 
 #if there are 49 flags in the PUEOFlags/$num directory, run the root analysis
 flag_count=$(ls | wc -l)
+echo $flag_count
+echo $num_jobs
 if [ $flag_count -eq $num_jobs ]
 then
     module load python/3.6-conda5.2

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/single_XF_output_PUEO.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Batch_Jobs/single_XF_output_PUEO.sh
@@ -44,7 +44,7 @@ python XFintoPUEO_Symmetric.py $NPOP $WorkingDir $RunName $gen $WorkingDir/Test_
 chmod 777 $WorkingDir/Test_Outputs/*
 
 mkdir -p -m775 $WorkingDir/Run_Outputs/$RunName/uan_files/${gen}_uan_files/$individual_number
-cp $WorkingDir/Run_Outputs/$RunName/${gen}_${individual_number}_*.uan $WorkingDir/Run_Outputs/$RunName/uan_files/${gen}_uan_files/$individual_number
+mv $WorkingDir/Run_Outputs/$RunName/${gen}_${individual_number}_*.uan $WorkingDir/Run_Outputs/$RunName/uan_files/${gen}_uan_files/$individual_number
 
 cd $WorkingDir/Test_Outputs
 # mod individual_number by NPOP
@@ -60,7 +60,7 @@ cp vv_el_${gen}_${individual_number} $PSIMDIR/pueoBuilder/components/pueoSim/dat
 cp vv_az_${gen}_${individual_number} $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated/vv_az_Toyon${run_num}
 
 cd $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated
-ls
+#ls
 
 chmod -R 777 $PSIMDIR/pueoBuilder/components/pueoSim/data/antennas/simulated/* 2>/dev/null
 

--- a/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B2_Parallel_Pueo.sh
+++ b/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop/Loop_Parts/Part_B/Part_B2_Parallel_Pueo.sh
@@ -122,8 +122,11 @@ do
 			parse=$(python Antenna_Performance_Metric/calculating_NNT.py $jobs_submitted $jobs_left $XFCOUNT $NNT $max_jobs)
 			NNT_per_sim=$(echo $parse | cut -d',' -f1)
 			num_jobs=$(echo $parse | cut -d',' -f2)
-
-			sbatch --array=1-$num_jobs --export=ALL,gen=$gen,WorkingDir=$WorkingDir,RunName=$RunName,Seeds=$Seeds,PSIMDIR=$PSIMDIR,NPOP=$NPOP,NNT=$NNT_per_sim,Exp=$exp,indiv=$indiv,num_jobs=$num_jobs --job-name=${RunName} Batch_Jobs/PueoCall_Array_Indiv.sh
+			# set the output file to Run_Outputs/$RunName/PUEO_Outputs/PUEOsim_$indiv_$SLURM_ARRAY_TASK_ID.output
+			sbatch --array=1-$num_jobs \
+				--export=ALL,gen=$gen,WorkingDir=$WorkingDir,RunName=$RunName,Seeds=$Seeds,PSIMDIR=$PSIMDIR,NPOP=$NPOP,NNT=$NNT_per_sim,Exp=$exp,indiv=$indiv,num_jobs=$num_jobs \
+				--job-name=${RunName} --output=$WorkingDir/Run_Outputs/$RunName/PUEO_Outputs/PUEOsim_${indiv}_%a.output  \
+				--error=$WorkingDir/Run_Outputs/$RunName/PUEO_Errors/PUEOsim_${indiv}_%a.error $WorkingDir/Batch_Jobs/PueoCall_Array_Indiv.sh
 			# move the cursor up 1 line
 			tput cuu 1
 			# move the file to the GPUFlags directory


### PR DESCRIPTION
Bugfixes for the 1/25 bugtesting runs found in `/fs/ess/PAS1960/HornEvolutionTestingOSC/GENETIS_PUEO/BiconeEvolution/current_antenna_evo_build/XF_Loop/Evolutionary_Loop`

- Changed hpol_data_t to correct variable name hpol_gain_t
- Fixed an indexing error in the fitness score aggregation
- Changed pueoSim job run time from 30 mins to 1 hour to make sure every job finishes
- changes a cp to mv to avoid run directory clutter
- specify a different pueoSim output file for every antenna
- Fix a bug in pueoSim's Seavey.cc file where we were dividing by 1,000 instead of 10,000 when determining the gain files to read in